### PR TITLE
prefer to use TreeNode's own selectable prop

### DIFF
--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -433,13 +433,13 @@ class Tree extends React.Component {
     const key = child.key || pos;
     const state = this.state;
     const props = this.props;
-    
-    //prefer to child's own selectable property if passed
+
+    // prefer to child's own selectable property if passed
     let selectable = props.selectable;
-    if (child.props.hasOwnProperty('selectable')){
+    if (child.props.hasOwnProperty('selectable')) {
       selectable = child.props.selectable;
     }
-    
+
     const cloneProps = {
       ref: 'treeNode-' + key,
       root: this,
@@ -463,7 +463,6 @@ class Tree extends React.Component {
       openAnimation: props.openAnimation,
       filterTreeNode: this.filterTreeNode.bind(this),
     };
-    
     if (props.checkable) {
       cloneProps.checkable = props.checkable;
       if (props.checkStrictly) {

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -433,12 +433,19 @@ class Tree extends React.Component {
     const key = child.key || pos;
     const state = this.state;
     const props = this.props;
+    
+    //prefer to child's own selectable property if passed
+    let selectable = props.selectable;
+    if (child.props.hasOwnProperty('selectable')){
+      selectable = child.props.selectable;
+    }
+    
     const cloneProps = {
       ref: 'treeNode-' + key,
       root: this,
       eventKey: key,
       pos,
-      selectable: props.selectable,
+      selectable: selectable,
       loadData: props.loadData,
       onMouseEnter: props.onMouseEnter,
       onMouseLeave: props.onMouseLeave,
@@ -456,6 +463,7 @@ class Tree extends React.Component {
       openAnimation: props.openAnimation,
       filterTreeNode: this.filterTreeNode.bind(this),
     };
+    
     if (props.checkable) {
       cloneProps.checkable = props.checkable;
       if (props.checkStrictly) {


### PR DESCRIPTION
Selectable was read from Tree props before, so we can't let a part of TreeNodes not selectable. Changed to: prefer to use TreeNode's own selectable prop while renderTreeNode.