### PR TITLE
Fixed calculation of offset for onDragEnterGap

### DIFF
--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -71,18 +71,17 @@ class Tree extends React.Component {
   }
 
   onDragEnterGap(e, treeNode) {
-    // console.log(e.pageY, getOffset(treeNode.refs.selectHandle), treeNode.props.eventKey);
-    const offsetTop = getOffset(treeNode.refs.selectHandle).top;
-    const offsetHeight = treeNode.refs.selectHandle.offsetHeight;
-    const pageY = e.pageY;
-    const gapHeight = 2;
+    let offsetTop = (0, getOffset)(treeNode.refs.selectHandle).top;
+    let offsetHeight = treeNode.refs.selectHandle.offsetHeight;
+    let pageY = e.pageY;
+    let gapHeight = 2;
     if (pageY > offsetTop + offsetHeight - gapHeight) {
-      this.dropPosition = 1;
-      return 1;
+        this.dropPosition = 1;
+        return 1;
     }
     if (pageY < offsetTop + gapHeight) {
-      this.dropPosition = -1;
-      return -1;
+        this.dropPosition = -1;
+        return -1;
     }
     this.dropPosition = 0;
     return 0;

--- a/src/util.js
+++ b/src/util.js
@@ -51,15 +51,26 @@ export function browser(navigator) {
 // }
 
 export function getOffset(ele) {
-  let el = ele;
-  let _x = 0;
-  let _y = 0;
-  while (el && !isNaN(el.offsetLeft) && !isNaN(el.offsetTop)) {
-    _x += el.offsetLeft - el.scrollLeft;
-    _y += el.offsetTop - el.scrollTop;
-    el = el.offsetParent;
+  let doc, win, docElem, rect;
+    
+  if (!ele.getClientRects().length) {
+    return { top: 0, left: 0 };
   }
-  return { top: _y, left: _x };
+
+  rect = ele.getBoundingClientRect();
+
+  if (rect.width || rect.height) {
+    doc = ele.ownerDocument;
+    win = doc.defaultView;
+    docElem = doc.documentElement;
+
+    return {
+      top: rect.top + win.pageYOffset - docElem.clientTop,
+      left: rect.left + win.pageXOffset - docElem.clientLeft
+    };
+  }
+
+  return rect;
 }
 
 function getChildrenlength(children) {


### PR DESCRIPTION
When the tree is displayed in a modal or similar, the current getOffset function does not calculate the correct offset for the onDragEnterGap function of the tree. This fixes the calculation and enables the tree on modals etc., too.