### PR TITLE
Changing onCheck prop callback invokation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rc-tree",
-  "version": "1.3.7",
-  "description": "tree ui component for react",
+  "version": "1.3.6",
+  "description": "fork of tree ui component for react",
   "keywords": [
     "react",
     "react-component",
@@ -13,14 +13,14 @@
     "assets/*.css",
     "lib"
   ],
-  "homepage": "http://github.com/react-component/tree",
-  "author": "hualei5280@gmail.com",
+  "homepage": "https://github.com/joaofribeiro/tree",
+  "author": "jr@mlabs.no",
   "repository": {
     "type": "git",
-    "url": "git@github.com:react-component/tree.git"
+    "url": "git@github.com:joaofribeiro/tree.git"
   },
   "bugs": {
-    "url": "http://github.com/react-component/tree/issues"
+    "url": "http://github.com/joaofribeiro/tree/issues"
   },
   "licenses": "MIT",
   "config": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rc-tree",
+  "name": "mt-rc-tree",
   "version": "1.3.6",
   "description": "fork of tree ui component for react",
   "keywords": [

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -230,7 +230,7 @@ class Tree extends React.Component {
           checkedKeys,
         });
       }
-      this.props.onCheck(checkedKeys, newSt);
+      this.props.onCheck(this.checkKeys, newSt);
     }
   }
 


### PR DESCRIPTION
When invoking the onCheck callback an object is passed instead of a checked keys array. This allows the parent component to access not only the checked keys array, but also the half checked keys.