### PR TITLE
Use isTreeNode rather than check item.type

### DIFF
--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -199,10 +199,10 @@ class TreeNode extends React.Component {
     const children = props.children;
     let newChildren = children;
     if (children &&
-      (children.type === TreeNode ||
+      (children.type && children.type.isTreeNode ||
       Array.isArray(children) &&
       children.every((item) => {
-        return item.type === TreeNode;
+        return item.type && item.type.isTreeNode;
       }))) {
       const cls = {
         [`${props.prefixCls}-child-tree`]: true,


### PR DESCRIPTION
This commit fixes the problem that TreeNode doesn't render when using React Hot Loader 3. RHL wraps component into a "proxy" internally for hot reloading. So item.type is the wrapped one which doesn't equal to the raw TreeNode before wrapping. See more: https://medium.com/@dan_abramov/hot-reloading-in-react-1140438583bf