### PR TITLE
Add doubleClick event and ability to set toggle functionality of onSelect

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 ---
+## 1.5.0 / 2017-02-10
+- add `onDoubleClick` API
+- add `toggleSelect` option for changing how selection works
 
 ## 1.4.0 / 2016-10-24
 - add `onDragEnd` API and fix related issues.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ see examples
 |showLine | whether show line | bool | false |
 |showIcon | whether show icon | bool | true |
 |selectable | whether can be selected | bool | true |
+|toggleSelect | whether additional clicks will toggle selection | bool | false |
 |multiple | whether multiple select | bool | false |
 |checkable | whether support checked | bool/React Node | false |
 |defaultExpandAll | expand all treeNodes | bool | false |
@@ -72,6 +73,7 @@ see examples
 |onExpand | fire on treeNode expand or not | function(expandedKeys, {expanded: bool, node}) | - |
 |onCheck | click the treeNode/checkbox to fire | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |
 |onSelect | click the treeNode to fire | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |
+|onDoubleClick | double click the treeNode to fire | function({node}) | - |
 |filterTreeNode | filter some treeNodes as you need. it should return true | function(node) | - |
 |loadData | load data asynchronously and the return value should be a promise | function(node) | - |
 |onRightClick | select current treeNode and show customized contextmenu | function({event,node}) | - |
@@ -117,11 +119,15 @@ npm start
 
 ## Test Case
 
-http://localhost:8018/tests/runner.html?coverage
+```
+npm test
+```
 
 ## Coverage
 
-http://localhost:8018/node_modules/rc-server/node_modules/node-jscover/lib/front-end/jscoverage.html?w=http://localhost:8018/tests/runner.html?coverage
+```
+npm run coverage
+```
 
 ## License
 rc-tree is released under the MIT license.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-tree",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "tree ui component for react",
   "keywords": [
     "react",

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -251,12 +251,23 @@ class Tree extends React.Component {
     }
   }
 
+  onDoubleClick(treeNode) {
+    this.props.onDoubleClick({ node: treeNode });
+  }
+
   onSelect(treeNode) {
     const props = this.props;
     const selectedKeys = [...this.state.selectedKeys];
     const eventKey = treeNode.props.eventKey;
     const index = selectedKeys.indexOf(eventKey);
     let selected;
+
+    if (!props.toggleSelect && index > -1) {
+      // If we are not allowing select/click to toggle then return
+      // since this node is already selected
+      return;
+    }
+
     if (index !== -1) {
       selected = false;
       selectedKeys.splice(index, 1);
@@ -470,6 +481,7 @@ class Tree extends React.Component {
       onMouseEnter: props.onMouseEnter,
       onMouseLeave: props.onMouseLeave,
       onRightClick: props.onRightClick,
+      onDoubleClick: props.onDoubleClick,
       prefixCls: props.prefixCls,
       showLine: props.showLine,
       showIcon: props.showIcon,
@@ -605,6 +617,7 @@ Tree.propTypes = {
   onCheck: PropTypes.func,
   onSelect: PropTypes.func,
   loadData: PropTypes.func,
+  onDoubleClick: PropTypes.func,
   onMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,
   onRightClick: PropTypes.func,
@@ -636,6 +649,7 @@ Tree.defaultProps = {
   onExpand: noop,
   onCheck: noop,
   onSelect: noop,
+  onDoubleClick: noop,
   onDragStart: noop,
   onDragEnter: noop,
   onDragOver: noop,

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -56,6 +56,10 @@ class TreeNode extends React.Component {
     this.props.root.onSelect(this);
   }
 
+  onDoubleClick() {
+    this.props.root.onDoubleClick(this);
+  }
+
   onMouseEnter(e) {
     e.preventDefault();
     this.props.root.onMouseEnter(e, this);
@@ -284,6 +288,12 @@ class TreeNode extends React.Component {
           // if (props.checkable) {
           //   this.onCheck();
           // }
+        };
+        domProps.onDoubleClick = (e) => {
+          e.preventDefault();
+          if (props.onDoubleClick) {
+            this.onDoubleClick();
+          }
         };
         if (props.onRightClick) {
           domProps.onContextMenu = this.onContextMenu;

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -335,10 +335,10 @@ describe('Tree', () => {
       ).toBe(true);
     });
 
-    it('fires select event', () => {
+    it('fires select event with toggle', () => {
       const handleSelect = jest.fn();
       const wrapper = mount(
-        <Tree selectable onSelect={handleSelect}>
+        <Tree selectable onSelect={handleSelect} toggleSelect>
           <TreeNode title="parent 1" key="0-0">
             <TreeNode title="leaf 1" key="0-0-0" />
           </TreeNode>
@@ -364,6 +364,50 @@ describe('Tree', () => {
         selectedNodes: [],
       });
     });
+
+    it('fires select event without toggle', () => {
+      const handleSelect = jest.fn();
+      const wrapper = mount(
+          <Tree selectable onSelect={handleSelect}>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+            </TreeNode>
+          </Tree>
+      );
+      const nodeContent = wrapper.find('.rc-tree-node-content-wrapper');
+      const node = wrapper.find(TreeNode).first().node;
+      const nodeElm = wrapper.find(Tree).props().children;
+
+      nodeContent.simulate('click');
+      expect(handleSelect).toBeCalledWith(['0-0'], {
+        event: 'select',
+        node,
+        selected: true,
+        selectedNodes: [nodeElm],
+      });
+
+      nodeContent.simulate('click');
+      expect(handleSelect).toBeCalledWith(['0-0'], {
+        event: 'select',
+        node,
+        selected: true,
+        selectedNodes: [nodeElm],
+      });
+    });
+  });
+
+  it('fires doubleClick event', () => {
+    const handleDoubleClick = jest.fn();
+    const wrapper = mount(
+        <Tree onDoubleClick={handleDoubleClick}>
+          <TreeNode title="parent 1" key="0-0">
+            <TreeNode title="leaf 1" key="0-0-0" />
+          </TreeNode>
+        </Tree>
+    );
+    const nodeElm = wrapper.find('.rc-tree-node-content-wrapper');
+    nodeElm.simulate('doubleclick');
+    expect(handleDoubleClick.mock.calls[0][0].node).toBe(wrapper.find(TreeNode).node);
   });
 
   it('fires rightClick event', () => {


### PR DESCRIPTION
This adds the ability to expose the double click event, and exposes configuration for how select works (toggle on additional clicks or not).

I also updated the readme test and coverage cases since it would appear this project has changed its testing since the readme was last updated.