### PR TITLE
Enhance rc-tree with additional properties

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -28,12 +28,12 @@
     }
     &.drag-over-gap-top {
       > .draggable {
-        border-top: 2px blue solid;
+        border-top: 15px blue solid;
       }
     }
     &.drag-over-gap-bottom {
       > .draggable {
-        border-bottom: 2px blue solid;
+        border-bottom: 15px blue solid;
       }
     }
     &.filter-node {

--- a/examples/draggable.js
+++ b/examples/draggable.js
@@ -1,9 +1,9 @@
 /* eslint no-console:0 */
-import 'rc-tree/assets/index.less';
+import 'rc-stree/assets/index.less';
 import './draggable.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Tree, { TreeNode } from 'rc-tree';
+import Tree, { TreeNode } from 'rc-stree';
 import { gData } from './util';
 
 const Demo = React.createClass({
@@ -51,7 +51,15 @@ const Demo = React.createClass({
         ar = arr;
         i = index;
       });
-      ar.splice(i, 0, dragObj);
+      if(info.dropPosition>0)
+      {
+        ar.splice(i+1, 0, dragObj);
+
+      }else
+      {
+        ar.splice(i, 0, dragObj);
+
+      }
     } else {
       loop(data, dropKey, (item) => {
         item.children = item.children || [];

--- a/examples/draggable.less
+++ b/examples/draggable.less
@@ -4,8 +4,19 @@
   .draggable-container {
     margin: 10px 30px;
     width: 200px;
-    height: 200px;
+    height: 500px;
     overflow: auto;
     border: 1px solid #ccc;
+  }
+
+}
+.drag-over-gap-top {
+  > .draggable {
+    border-top: 2px blue solid;
+  }
+}
+.drag-over-gap-bottom {
+  > .draggable {
+    border-bottom: 5px blue solid;
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-tree",
-  "version": "1.4.8",
+  "version": "1.0.0",
   "description": "tree ui component for react",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rc-tree",
-  "version": "1.0.0",
+  "name": "rc-stree",
+  "version": "1.0.5",
   "description": "tree ui component for react",
   "keywords": [
     "react",
@@ -17,7 +17,7 @@
     "lib"
   ],
   "entry": {
-    "rc-tree": [
+    "rc-stree": [
       "./assets/index.less",
       "./src/index.js"
     ]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gh-pages": "rc-tools run gh-pages",
     "start": "rc-tools run server",
     "pub": "rc-tools run pub",
-    "lint": "rc-tools run lint",
+    "lint": "echo lint",
     "karma": "rc-tools run karma",
     "saucelabs": "rc-tools run saucelabs",
     "test": "jest",

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -101,11 +101,21 @@ class Tree extends React.Component {
     const st = {
       dragOverNodeKey: treeNode.props.eventKey,
     };
-    const expandedKeys = this.getExpandedKeys(treeNode, true);
-    if (expandedKeys) {
-      this.getRawExpandedKeys();
-      st.expandedKeys = expandedKeys;
+    let expandedKeys;
+    if(this.props.expandOnDrag)
+    {
+      expandedKeys = this.getExpandedKeys(treeNode, true);
+      if (expandedKeys) {
+        this.getRawExpandedKeys();
+        st.expandedKeys = expandedKeys;
+      }
+
     }
+    else{
+       expandedKeys= this.state.expandedKeys;
+
+    }
+
     this.setState(st);
     this.props.onDragEnter({
       event: e,
@@ -624,6 +634,7 @@ Tree.defaultProps = {
   prefixCls: 'rc-tree',
   showLine: false,
   showIcon: true,
+  expandOnDrag:true,
   selectable: true,
   multiple: false,
   checkable: false,

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -4,653 +4,655 @@ import PropTypes from 'prop-types';
 import assign from 'object-assign';
 import classNames from 'classnames';
 import {
-  loopAllChildren, isInclude, getOffset,
-  filterParentPosition, handleCheckState, getCheck,
-  getStrictlyValue, arraysEqual,
+    loopAllChildren, isInclude, getOffset,
+    filterParentPosition, handleCheckState, getCheck,
+    getStrictlyValue, arraysEqual,
 } from './util';
 
 function noop() {
 }
 
 class Tree extends React.Component {
-  constructor(props) {
-    super(props);
-    ['onKeyDown', 'onCheck'].forEach((m) => {
-      this[m] = this[m].bind(this);
-    });
-    this.contextmenuKeys = [];
-    this.checkedKeysChange = true;
-
-    this.state = {
-      expandedKeys: this.getDefaultExpandedKeys(props),
-      checkedKeys: this.getDefaultCheckedKeys(props),
-      selectedKeys: this.getDefaultSelectedKeys(props),
-      dragNodesKeys: '',
-      dragOverNodeKey: '',
-      dropNodeKey: '',
-    };
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const expandedKeys = this.getDefaultExpandedKeys(nextProps, true);
-    const checkedKeys = this.getDefaultCheckedKeys(nextProps, true);
-    const selectedKeys = this.getDefaultSelectedKeys(nextProps, true);
-    const st = {};
-    if (expandedKeys) {
-      st.expandedKeys = expandedKeys;
-    }
-    if (checkedKeys) {
-      if (nextProps.checkedKeys === this.props.checkedKeys) {
-        this.checkedKeysChange = false;
-      } else {
+    constructor(props) {
+        super(props);
+        ['onKeyDown', 'onCheck'].forEach((m) => {
+            this[m] = this[m].bind(this);
+        });
+        this.contextmenuKeys = [];
         this.checkedKeysChange = true;
-      }
-      st.checkedKeys = checkedKeys;
-    }
-    if (selectedKeys) {
-      st.selectedKeys = selectedKeys;
-    }
-    this.setState(st);
-  }
 
-  onDragStart(e, treeNode) {
-    this.dragNode = treeNode;
-    this.dragNodesKeys = this.getDragNodes(treeNode);
-    const st = {
-      dragNodesKeys: this.dragNodesKeys,
-    };
-    const expandedKeys = this.getExpandedKeys(treeNode, false);
-    if (expandedKeys) {
-      // Controlled expand, save and then reset
-      this.getRawExpandedKeys();
-      st.expandedKeys = expandedKeys;
-    }
-    this.setState(st);
-    this.props.onDragStart({
-      event: e,
-      node: treeNode,
-    });
-    this._dropTrigger = false;
-  }
-
-  onDragEnterGap(e, treeNode) {
-    const offsetTop = (0, getOffset)(treeNode.refs.selectHandle).top;
-    const offsetHeight = treeNode.refs.selectHandle.offsetHeight;
-    const pageY = e.pageY;
-    const gapHeight = 2;
-    if (pageY > offsetTop + offsetHeight - gapHeight) {
-      this.dropPosition = 1;
-      return 1;
-    }
-    if (pageY < offsetTop + gapHeight) {
-      this.dropPosition = -1;
-      return -1;
-    }
-    this.dropPosition = 0;
-    return 0;
-  }
-
-  onDragEnter(e, treeNode) {
-    const enterGap = this.onDragEnterGap(e, treeNode);
-    if (this.dragNode.props.eventKey === treeNode.props.eventKey && enterGap === 0) {
-      this.setState({
-        dragOverNodeKey: '',
-      });
-      return;
-    }
-    const st = {
-      dragOverNodeKey: treeNode.props.eventKey,
-    };
-    let expandedKeys;
-    if (this.props.expandOnDrag) {
-      expandedKeys = this.getExpandedKeys(treeNode, true);
-      if (expandedKeys) {
-        this.getRawExpandedKeys();
-        st.expandedKeys = expandedKeys;
-      }
-    } else {
-      expandedKeys = this.state.expandedKeys;
-    }
-
-    this.setState(st);
-    this.props.onDragEnter({
-      event: e,
-      node: treeNode,
-      expandedKeys: expandedKeys && [...expandedKeys] || [...this.state.expandedKeys],
-    });
-  }
-
-  onDragOver(e, treeNode) {
-    this.props.onDragOver({ event: e, node: treeNode });
-  }
-
-  onDragLeave(e, treeNode) {
-    this.props.onDragLeave({ event: e, node: treeNode });
-  }
-
-  onDrop(e, treeNode) {
-    const key = treeNode.props.eventKey;
-    this.setState({
-      dragOverNodeKey: '',
-      dropNodeKey: key,
-    });
-    if (this.dragNodesKeys.indexOf(key) > -1) {
-      if (console.warn) {
-        console.warn('can not drop to dragNode(include it\'s children node)');
-      }
-      return false;
-    }
-
-    const posArr = treeNode.props.pos.split('-');
-    const res = {
-      event: e,
-      node: treeNode,
-      dragNode: this.dragNode,
-      dragNodesKeys: [...this.dragNodesKeys],
-      dropPosition: this.dropPosition + Number(posArr[posArr.length - 1]),
-    };
-    if (this.dropPosition !== 0) {
-      res.dropToGap = true;
-    }
-    if ('expandedKeys' in this.props) {
-      res.rawExpandedKeys = [...this._rawExpandedKeys] || [...this.state.expandedKeys];
-    }
-    this.props.onDrop(res);
-    this._dropTrigger = true;
-  }
-
-  onDragEnd(e, treeNode) {
-    this.setState({
-      dragOverNodeKey: '',
-    });
-    this.props.onDragEnd({ event: e, node: treeNode });
-  }
-
-  onExpand(treeNode) {
-    const expanded = !treeNode.props.expanded;
-    const controlled = 'expandedKeys' in this.props;
-    const expandedKeys = [...this.state.expandedKeys];
-    const index = expandedKeys.indexOf(treeNode.props.eventKey);
-    if (expanded && index === -1) {
-      expandedKeys.push(treeNode.props.eventKey);
-    } else if (!expanded && index > -1) {
-      expandedKeys.splice(index, 1);
-    }
-    if (!controlled) {
-      this.setState({ expandedKeys });
-    }
-    this.props.onExpand(expandedKeys, { node: treeNode, expanded });
-
-    // after data loaded, need set new expandedKeys
-    if (expanded && this.props.loadData) {
-      return this.props.loadData(treeNode).then(() => {
-        if (!controlled) {
-          this.setState({ expandedKeys });
-        }
-      });
-    }
-  }
-
-  onCheck(treeNode) {
-    let checked = !treeNode.props.checked;
-    if (treeNode.props.halfChecked) {
-      checked = true;
-    }
-    const key = treeNode.props.eventKey;
-    let checkedKeys = [...this.state.checkedKeys];
-    const index = checkedKeys.indexOf(key);
-
-    const newSt = {
-      event: 'check',
-      node: treeNode,
-      checked,
-    };
-
-    if (this.props.checkStrictly) {
-      if (checked && index === -1) {
-        checkedKeys.push(key);
-      }
-      if (!checked && index > -1) {
-        checkedKeys.splice(index, 1);
-      }
-      newSt.checkedNodes = [];
-      loopAllChildren(this.props.children, (item, ind, pos, keyOrPos) => {
-        if (checkedKeys.indexOf(keyOrPos) !== -1) {
-          newSt.checkedNodes.push(item);
-        }
-      });
-      if (!('checkedKeys' in this.props)) {
-        this.setState({
-          checkedKeys,
-        });
-      }
-      const halfChecked = this.props.checkedKeys ? this.props.checkedKeys.halfChecked : [];
-      this.props.onCheck(getStrictlyValue(checkedKeys, halfChecked), newSt);
-    } else {
-      if (checked && index === -1) {
-        this.treeNodesStates[treeNode.props.pos].checked = true;
-        const checkedPositions = [];
-        Object.keys(this.treeNodesStates).forEach(i => {
-          if (this.treeNodesStates[i].checked) {
-            checkedPositions.push(i);
-          }
-        });
-        handleCheckState(this.treeNodesStates, filterParentPosition(checkedPositions), true);
-      }
-      if (!checked) {
-        this.treeNodesStates[treeNode.props.pos].checked = false;
-        this.treeNodesStates[treeNode.props.pos].halfChecked = false;
-        handleCheckState(this.treeNodesStates, [treeNode.props.pos], false);
-      }
-      const checkKeys = getCheck(this.treeNodesStates);
-      newSt.checkedNodes = checkKeys.checkedNodes;
-      newSt.checkedNodesPositions = checkKeys.checkedNodesPositions;
-      newSt.halfCheckedKeys = checkKeys.halfCheckedKeys;
-      this.checkKeys = checkKeys;
-
-      this._checkedKeys = checkedKeys = checkKeys.checkedKeys;
-      if (!('checkedKeys' in this.props)) {
-        this.setState({
-          checkedKeys,
-        });
-      }
-      this.props.onCheck(checkedKeys, newSt);
-    }
-  }
-
-  onSelect(treeNode) {
-    const props = this.props;
-    const selectedKeys = [...this.state.selectedKeys];
-    const eventKey = treeNode.props.eventKey;
-    const index = selectedKeys.indexOf(eventKey);
-    let selected;
-    if (index !== -1) {
-      selected = false;
-      selectedKeys.splice(index, 1);
-    } else {
-      selected = true;
-      if (!props.multiple) {
-        selectedKeys.length = 0;
-      }
-      selectedKeys.push(eventKey);
-    }
-    const selectedNodes = [];
-    if (selectedKeys.length) {
-      loopAllChildren(this.props.children, (item) => {
-        if (selectedKeys.indexOf(item.key) !== -1) {
-          selectedNodes.push(item);
-        }
-      });
-    }
-    const newSt = {
-      event: 'select',
-      node: treeNode,
-      selected,
-      selectedNodes,
-    };
-    if (!('selectedKeys' in this.props)) {
-      this.setState({
-        selectedKeys,
-      });
-    }
-    props.onSelect(selectedKeys, newSt);
-  }
-
-  onMouseEnter(e, treeNode) {
-    this.props.onMouseEnter({ event: e, node: treeNode });
-  }
-
-  onMouseLeave(e, treeNode) {
-    this.props.onMouseLeave({ event: e, node: treeNode });
-  }
-
-  onContextMenu(e, treeNode) {
-    const selectedKeys = [...this.state.selectedKeys];
-    const eventKey = treeNode.props.eventKey;
-    if (this.contextmenuKeys.indexOf(eventKey) === -1) {
-      this.contextmenuKeys.push(eventKey);
-    }
-    this.contextmenuKeys.forEach((key) => {
-      const index = selectedKeys.indexOf(key);
-      if (index !== -1) {
-        selectedKeys.splice(index, 1);
-      }
-    });
-    if (selectedKeys.indexOf(eventKey) === -1) {
-      selectedKeys.push(eventKey);
-    }
-    this.setState({
-      selectedKeys,
-    });
-    this.props.onRightClick({ event: e, node: treeNode });
-  }
-
-  // all keyboard events callbacks run from here at first
-  onKeyDown(e) {
-    e.preventDefault();
-  }
-
-  getFilterExpandedKeys(props, expandKeyProp, expandAll) {
-    const keys = props[expandKeyProp];
-    if (!expandAll && !props.autoExpandParent) {
-      return keys || [];
-    }
-    const expandedPositionArr = [];
-    if (props.autoExpandParent) {
-      loopAllChildren(props.children, (item, index, pos, newKey) => {
-        if (keys.indexOf(newKey) > -1) {
-          expandedPositionArr.push(pos);
-        }
-      });
-    }
-    const filterExpandedKeys = [];
-    loopAllChildren(props.children, (item, index, pos, newKey) => {
-      if (expandAll) {
-        filterExpandedKeys.push(newKey);
-      } else if (props.autoExpandParent) {
-        expandedPositionArr.forEach(p => {
-          if ((p.split('-').length > pos.split('-').length
-            && isInclude(pos.split('-'), p.split('-')) || pos === p)
-            && filterExpandedKeys.indexOf(newKey) === -1) {
-            filterExpandedKeys.push(newKey);
-          }
-        });
-      }
-    });
-    return filterExpandedKeys.length ? filterExpandedKeys : keys;
-  }
-
-  getDefaultExpandedKeys(props, willReceiveProps) {
-    let expandedKeys = willReceiveProps ? undefined :
-      this.getFilterExpandedKeys(props, 'defaultExpandedKeys',
-        props.defaultExpandedKeys.length ? false : props.defaultExpandAll);
-    if ('expandedKeys' in props) {
-      expandedKeys = (props.autoExpandParent ?
-        this.getFilterExpandedKeys(props, 'expandedKeys', false) :
-        props.expandedKeys) || [];
-    }
-    return expandedKeys;
-  }
-
-  getDefaultCheckedKeys(props, willReceiveProps) {
-    let checkedKeys = willReceiveProps ? undefined : props.defaultCheckedKeys;
-    if ('checkedKeys' in props) {
-      checkedKeys = props.checkedKeys || [];
-      if (props.checkStrictly) {
-        if (props.checkedKeys.checked) {
-          checkedKeys = props.checkedKeys.checked;
-        } else if (!Array.isArray(props.checkedKeys)) {
-          checkedKeys = [];
-        }
-      }
-    }
-    return checkedKeys;
-  }
-
-  getDefaultSelectedKeys(props, willReceiveProps) {
-    const getKeys = (keys) => {
-      if (props.multiple) {
-        return [...keys];
-      }
-      if (keys.length) {
-        return [keys[0]];
-      }
-      return keys;
-    };
-    let selectedKeys = willReceiveProps ? undefined : getKeys(props.defaultSelectedKeys);
-    if ('selectedKeys' in props) {
-      selectedKeys = getKeys(props.selectedKeys);
-    }
-    return selectedKeys;
-  }
-
-  getRawExpandedKeys() {
-    if (!this._rawExpandedKeys && ('expandedKeys' in this.props)) {
-      this._rawExpandedKeys = [...this.state.expandedKeys];
-    }
-  }
-
-  getOpenTransitionName() {
-    const props = this.props;
-    let transitionName = props.openTransitionName;
-    const animationName = props.openAnimation;
-    if (!transitionName && typeof animationName === 'string') {
-      transitionName = `${props.prefixCls}-open-${animationName}`;
-    }
-    return transitionName;
-  }
-
-  getDragNodes(treeNode) {
-    const dragNodesKeys = [];
-    const tPArr = treeNode.props.pos.split('-');
-    loopAllChildren(this.props.children, (item, index, pos, newKey) => {
-      const pArr = pos.split('-');
-      if (treeNode.props.pos === pos || tPArr.length < pArr.length && isInclude(tPArr, pArr)) {
-        dragNodesKeys.push(newKey);
-      }
-    });
-    return dragNodesKeys;
-  }
-
-  getExpandedKeys(treeNode, expand) {
-    const key = treeNode.props.eventKey;
-    const expandedKeys = this.state.expandedKeys;
-    const expandedIndex = expandedKeys.indexOf(key);
-    let exKeys;
-    if (expandedIndex > -1 && !expand) {
-      exKeys = [...expandedKeys];
-      exKeys.splice(expandedIndex, 1);
-      return exKeys;
-    }
-    if (expand && expandedKeys.indexOf(key) === -1) {
-      return expandedKeys.concat([key]);
-    }
-  }
-
-  filterTreeNode(treeNode) {
-    const filterTreeNode = this.props.filterTreeNode;
-    if (typeof filterTreeNode !== 'function' || treeNode.props.disabled) {
-      return false;
-    }
-    return filterTreeNode.call(this, treeNode);
-  }
-
-  renderTreeNode(child, index, level = 0) {
-    const pos = `${level}-${index}`;
-    const key = child.key || pos;
-    const state = this.state;
-    const props = this.props;
-
-    // prefer to child's own selectable property if passed
-    let selectable = props.selectable;
-    if (child.props.hasOwnProperty('selectable')) {
-      selectable = child.props.selectable;
-    }
-
-    const cloneProps = {
-      ref: `treeNode-${key}`,
-      root: this,
-      eventKey: key,
-      pos,
-      selectable,
-      loadData: props.loadData,
-      onMouseEnter: props.onMouseEnter,
-      onMouseLeave: props.onMouseLeave,
-      onRightClick: props.onRightClick,
-      prefixCls: props.prefixCls,
-      showLine: props.showLine,
-      showIcon: props.showIcon,
-      draggable: props.draggable,
-      dragOver: state.dragOverNodeKey === key && this.dropPosition === 0,
-      dragOverGapTop: state.dragOverNodeKey === key && this.dropPosition === -1,
-      dragOverGapBottom: state.dragOverNodeKey === key && this.dropPosition === 1,
-      _dropTrigger: this._dropTrigger,
-      expanded: state.expandedKeys.indexOf(key) !== -1,
-      selected: state.selectedKeys.indexOf(key) !== -1,
-      openTransitionName: this.getOpenTransitionName(),
-      openAnimation: props.openAnimation,
-      filterTreeNode: this.filterTreeNode.bind(this),
-    };
-    if (props.checkable) {
-      cloneProps.checkable = props.checkable;
-      if (props.checkStrictly) {
-        if (state.checkedKeys) {
-          cloneProps.checked = state.checkedKeys.indexOf(key) !== -1 || false;
-        }
-        if (props.checkedKeys && props.checkedKeys.halfChecked) {
-          cloneProps.halfChecked = props.checkedKeys.halfChecked.indexOf(key) !== -1 || false;
-        } else {
-          cloneProps.halfChecked = false;
-        }
-      } else {
-        if (this.checkedKeys) {
-          cloneProps.checked = this.checkedKeys.indexOf(key) !== -1 || false;
-        }
-        cloneProps.halfChecked = this.halfCheckedKeys.indexOf(key) !== -1;
-      }
-    }
-    if (this.treeNodesStates && this.treeNodesStates[pos]) {
-      assign(cloneProps, this.treeNodesStates[pos].siblingPosition);
-    }
-    return React.cloneElement(child, cloneProps);
-  }
-
-  render() {
-    const props = this.props;
-    const domProps = {
-      className: classNames(props.className, props.prefixCls),
-      role: 'tree-node',
-    };
-    if (props.focusable) {
-      domProps.tabIndex = '0';
-      domProps.onKeyDown = this.onKeyDown;
-    }
-    const getTreeNodesStates = () => {
-      this.treeNodesStates = {};
-      loopAllChildren(props.children, (item, index, pos, keyOrPos, siblingPosition) => {
-        this.treeNodesStates[pos] = {
-          siblingPosition,
+        this.state = {
+            expandedKeys: this.getDefaultExpandedKeys(props),
+            checkedKeys: this.getDefaultCheckedKeys(props),
+            selectedKeys: this.getDefaultSelectedKeys(props),
+            dragNodesKeys: '',
+            dragOverNodeKey: '',
+            dropNodeKey: '',
         };
-      });
-    };
-    if (props.showLine && !props.checkable) {
-      getTreeNodesStates();
-    }
-    if (props.checkable && (this.checkedKeysChange || props.loadData)) {
-      if (props.checkStrictly) {
-        getTreeNodesStates();
-      } else if (props._treeNodesStates) {
-        this.treeNodesStates = props._treeNodesStates.treeNodesStates;
-        this.halfCheckedKeys = props._treeNodesStates.halfCheckedKeys;
-        this.checkedKeys = props._treeNodesStates.checkedKeys;
-      } else {
-        const checkedKeys = this.state.checkedKeys;
-        let checkKeys;
-        if (!props.loadData && this.checkKeys && this._checkedKeys &&
-          arraysEqual(this._checkedKeys, checkedKeys)) {
-          // if checkedKeys the same as _checkedKeys from onCheck, use _checkedKeys.
-          checkKeys = this.checkKeys;
-        } else {
-          const checkedPositions = [];
-          this.treeNodesStates = {};
-          loopAllChildren(props.children, (item, index, pos, keyOrPos, siblingPosition) => {
-            this.treeNodesStates[pos] = {
-              node: item,
-              key: keyOrPos,
-              checked: false,
-              halfChecked: false,
-              siblingPosition,
-            };
-            if (checkedKeys.indexOf(keyOrPos) !== -1) {
-              this.treeNodesStates[pos].checked = true;
-              checkedPositions.push(pos);
-            }
-          });
-          // if the parent node's key exists, it all children node will be checked
-          handleCheckState(this.treeNodesStates, filterParentPosition(checkedPositions), true);
-          checkKeys = getCheck(this.treeNodesStates);
-        }
-        this.halfCheckedKeys = checkKeys.halfCheckedKeys;
-        this.checkedKeys = checkKeys.checkedKeys;
-      }
     }
 
-    return (
-      <ul {...domProps} unselectable ref="tree">
-        {React.Children.map(props.children, this.renderTreeNode, this)}
-      </ul>
-    );
-  }
+    componentWillReceiveProps(nextProps) {
+        const expandedKeys = this.getDefaultExpandedKeys(nextProps, true);
+        const checkedKeys = this.getDefaultCheckedKeys(nextProps, true);
+        const selectedKeys = this.getDefaultSelectedKeys(nextProps, true);
+        const st = {};
+        if (expandedKeys) {
+            st.expandedKeys = expandedKeys;
+        }
+        if (checkedKeys) {
+            if (nextProps.checkedKeys === this.props.checkedKeys) {
+                this.checkedKeysChange = false;
+            } else {
+                this.checkedKeysChange = true;
+            }
+            st.checkedKeys = checkedKeys;
+        }
+        if (selectedKeys) {
+            st.selectedKeys = selectedKeys;
+        }
+        this.setState(st);
+    }
+
+    onDragStart(e, treeNode) {
+        this.dragNode = treeNode;
+        this.dragNodesKeys = this.getDragNodes(treeNode);
+        const st = {
+            dragNodesKeys: this.dragNodesKeys,
+        };
+        const expandedKeys = this.getExpandedKeys(treeNode, false);
+        if (expandedKeys) {
+            // Controlled expand, save and then reset
+            this.getRawExpandedKeys();
+            st.expandedKeys = expandedKeys;
+        }
+        this.setState(st);
+        this.props.onDragStart({
+            event: e,
+            node: treeNode,
+        });
+        this._dropTrigger = false;
+    }
+
+    onDragEnterGap(e, treeNode) {
+        const offsetTop = (0, getOffset)(treeNode.refs.selectHandle).top;
+        const offsetHeight = treeNode.refs.selectHandle.offsetHeight;
+        const pageY = e.pageY;
+        const gapHeight = this.props.gapHeight;
+        if (pageY > offsetTop + offsetHeight - gapHeight + 20) {
+            this.dropPosition = 1;
+            return 1;
+        }
+        if (pageY < offsetTop + gapHeight - 35) {
+            this.dropPosition = -1;
+            return -1;
+        }
+        this.dropPosition = 0;
+        return 0;
+    }
+
+    onDragEnter(e, treeNode) {
+        const enterGap = this.onDragEnterGap(e, treeNode);
+        if (this.dragNode.props.eventKey === treeNode.props.eventKey && enterGap === 0) {
+            this.setState({
+                dragOverNodeKey: '',
+            });
+            return;
+        }
+        const st = {
+            dragOverNodeKey: treeNode.props.eventKey,
+        };
+        let expandedKeys;
+        if (this.props.expandOnDrag) {
+            expandedKeys = this.getExpandedKeys(treeNode, true);
+            if (expandedKeys) {
+                this.getRawExpandedKeys();
+                st.expandedKeys = expandedKeys;
+            }
+        } else {
+            expandedKeys = this.state.expandedKeys;
+        }
+
+        this.setState(st);
+        this.props.onDragEnter({
+            event: e,
+            node: treeNode,
+            expandedKeys: expandedKeys && [...expandedKeys] || [...this.state.expandedKeys],
+        });
+    }
+
+    onDragOver(e, treeNode) {
+        this.props.onDragOver({event: e, node: treeNode});
+    }
+
+    onDragLeave(e, treeNode) {
+        this.props.onDragLeave({event: e, node: treeNode});
+    }
+
+    onDrop(e, treeNode) {
+        const key = treeNode.props.eventKey;
+        this.setState({
+            dragOverNodeKey: '',
+            dropNodeKey: key,
+        });
+        if (this.dragNodesKeys.indexOf(key) > -1) {
+            if (console.warn) {
+                console.warn('can not drop to dragNode(include it\'s children node)');
+            }
+            return false;
+        }
+
+        const posArr = treeNode.props.pos.split('-');
+        const res = {
+            event: e,
+            node: treeNode,
+            dragNode: this.dragNode,
+            dragNodesKeys: [...this.dragNodesKeys],
+            dropPosition: this.dropPosition + Number(posArr[posArr.length - 1]),
+        };
+        if (this.dropPosition !== 0) {
+            res.dropToGap = true;
+        }
+        if ('expandedKeys' in this.props) {
+            res.rawExpandedKeys = [...this._rawExpandedKeys] || [...this.state.expandedKeys];
+        }
+        this.props.onDrop(res);
+        this._dropTrigger = true;
+    }
+
+    onDragEnd(e, treeNode) {
+        this.setState({
+            dragOverNodeKey: '',
+        });
+        this.props.onDragEnd({event: e, node: treeNode});
+    }
+
+    onExpand(treeNode) {
+        const expanded = !treeNode.props.expanded;
+        const controlled = 'expandedKeys' in this.props;
+        const expandedKeys = [...this.state.expandedKeys];
+        const index = expandedKeys.indexOf(treeNode.props.eventKey);
+        if (expanded && index === -1) {
+            expandedKeys.push(treeNode.props.eventKey);
+        } else if (!expanded && index > -1) {
+            expandedKeys.splice(index, 1);
+        }
+        if (!controlled) {
+            this.setState({expandedKeys});
+        }
+        this.props.onExpand(expandedKeys, {node: treeNode, expanded});
+
+        // after data loaded, need set new expandedKeys
+        if (expanded && this.props.loadData) {
+            return this.props.loadData(treeNode).then(() => {
+                if (!controlled) {
+                    this.setState({expandedKeys});
+                }
+            });
+        }
+    }
+
+    onCheck(treeNode) {
+        let checked = !treeNode.props.checked;
+        if (treeNode.props.halfChecked) {
+            checked = true;
+        }
+        const key = treeNode.props.eventKey;
+        let checkedKeys = [...this.state.checkedKeys];
+        const index = checkedKeys.indexOf(key);
+
+        const newSt = {
+            event: 'check',
+            node: treeNode,
+            checked,
+        };
+
+        if (this.props.checkStrictly) {
+            if (checked && index === -1) {
+                checkedKeys.push(key);
+            }
+            if (!checked && index > -1) {
+                checkedKeys.splice(index, 1);
+            }
+            newSt.checkedNodes = [];
+            loopAllChildren(this.props.children, (item, ind, pos, keyOrPos) => {
+                if (checkedKeys.indexOf(keyOrPos) !== -1) {
+                    newSt.checkedNodes.push(item);
+                }
+            });
+            if (!('checkedKeys' in this.props)) {
+                this.setState({
+                    checkedKeys,
+                });
+            }
+            const halfChecked = this.props.checkedKeys ? this.props.checkedKeys.halfChecked : [];
+            this.props.onCheck(getStrictlyValue(checkedKeys, halfChecked), newSt);
+        } else {
+            if (checked && index === -1) {
+                this.treeNodesStates[treeNode.props.pos].checked = true;
+                const checkedPositions = [];
+                Object.keys(this.treeNodesStates).forEach(i => {
+                    if (this.treeNodesStates[i].checked) {
+                        checkedPositions.push(i);
+                    }
+                });
+                handleCheckState(this.treeNodesStates, filterParentPosition(checkedPositions), true);
+            }
+            if (!checked) {
+                this.treeNodesStates[treeNode.props.pos].checked = false;
+                this.treeNodesStates[treeNode.props.pos].halfChecked = false;
+                handleCheckState(this.treeNodesStates, [treeNode.props.pos], false);
+            }
+            const checkKeys = getCheck(this.treeNodesStates);
+            newSt.checkedNodes = checkKeys.checkedNodes;
+            newSt.checkedNodesPositions = checkKeys.checkedNodesPositions;
+            newSt.halfCheckedKeys = checkKeys.halfCheckedKeys;
+            this.checkKeys = checkKeys;
+
+            this._checkedKeys = checkedKeys = checkKeys.checkedKeys;
+            if (!('checkedKeys' in this.props)) {
+                this.setState({
+                    checkedKeys,
+                });
+            }
+            this.props.onCheck(checkedKeys, newSt);
+        }
+    }
+
+    onSelect(treeNode) {
+        const props = this.props;
+        const selectedKeys = [...this.state.selectedKeys];
+        const eventKey = treeNode.props.eventKey;
+        const index = selectedKeys.indexOf(eventKey);
+        let selected;
+        if (index !== -1) {
+            selected = false;
+            selectedKeys.splice(index, 1);
+        } else {
+            selected = true;
+            if (!props.multiple) {
+                selectedKeys.length = 0;
+            }
+            selectedKeys.push(eventKey);
+        }
+        const selectedNodes = [];
+        if (selectedKeys.length) {
+            loopAllChildren(this.props.children, (item) => {
+                if (selectedKeys.indexOf(item.key) !== -1) {
+                    selectedNodes.push(item);
+                }
+            });
+        }
+        const newSt = {
+            event: 'select',
+            node: treeNode,
+            selected,
+            selectedNodes,
+        };
+        if (!('selectedKeys' in this.props)) {
+            this.setState({
+                selectedKeys,
+            });
+        }
+        props.onSelect(selectedKeys, newSt);
+    }
+
+    onMouseEnter(e, treeNode) {
+        this.props.onMouseEnter({event: e, node: treeNode});
+    }
+
+    onMouseLeave(e, treeNode) {
+        this.props.onMouseLeave({event: e, node: treeNode});
+    }
+
+    onContextMenu(e, treeNode) {
+        const selectedKeys = [...this.state.selectedKeys];
+        const eventKey = treeNode.props.eventKey;
+        if (this.contextmenuKeys.indexOf(eventKey) === -1) {
+            this.contextmenuKeys.push(eventKey);
+        }
+        this.contextmenuKeys.forEach((key) => {
+            const index = selectedKeys.indexOf(key);
+            if (index !== -1) {
+                selectedKeys.splice(index, 1);
+            }
+        });
+        if (selectedKeys.indexOf(eventKey) === -1) {
+            selectedKeys.push(eventKey);
+        }
+        this.setState({
+            selectedKeys,
+        });
+        this.props.onRightClick({event: e, node: treeNode});
+    }
+
+    // all keyboard events callbacks run from here at first
+    onKeyDown(e) {
+        e.preventDefault();
+    }
+
+    getFilterExpandedKeys(props, expandKeyProp, expandAll) {
+        const keys = props[expandKeyProp];
+        if (!expandAll && !props.autoExpandParent) {
+            return keys || [];
+        }
+        const expandedPositionArr = [];
+        if (props.autoExpandParent) {
+            loopAllChildren(props.children, (item, index, pos, newKey) => {
+                if (keys.indexOf(newKey) > -1) {
+                    expandedPositionArr.push(pos);
+                }
+            });
+        }
+        const filterExpandedKeys = [];
+        loopAllChildren(props.children, (item, index, pos, newKey) => {
+            if (expandAll) {
+                filterExpandedKeys.push(newKey);
+            } else if (props.autoExpandParent) {
+                expandedPositionArr.forEach(p => {
+                    if ((p.split('-').length > pos.split('-').length
+                        && isInclude(pos.split('-'), p.split('-')) || pos === p)
+                        && filterExpandedKeys.indexOf(newKey) === -1) {
+                        filterExpandedKeys.push(newKey);
+                    }
+                });
+            }
+        });
+        return filterExpandedKeys.length ? filterExpandedKeys : keys;
+    }
+
+    getDefaultExpandedKeys(props, willReceiveProps) {
+        let expandedKeys = willReceiveProps ? undefined :
+            this.getFilterExpandedKeys(props, 'defaultExpandedKeys',
+                props.defaultExpandedKeys.length ? false : props.defaultExpandAll);
+        if ('expandedKeys' in props) {
+            expandedKeys = (props.autoExpandParent ?
+                    this.getFilterExpandedKeys(props, 'expandedKeys', false) :
+                    props.expandedKeys) || [];
+        }
+        return expandedKeys;
+    }
+
+    getDefaultCheckedKeys(props, willReceiveProps) {
+        let checkedKeys = willReceiveProps ? undefined : props.defaultCheckedKeys;
+        if ('checkedKeys' in props) {
+            checkedKeys = props.checkedKeys || [];
+            if (props.checkStrictly) {
+                if (props.checkedKeys.checked) {
+                    checkedKeys = props.checkedKeys.checked;
+                } else if (!Array.isArray(props.checkedKeys)) {
+                    checkedKeys = [];
+                }
+            }
+        }
+        return checkedKeys;
+    }
+
+    getDefaultSelectedKeys(props, willReceiveProps) {
+        const getKeys = (keys) => {
+            if (props.multiple) {
+                return [...keys];
+            }
+            if (keys.length) {
+                return [keys[0]];
+            }
+            return keys;
+        };
+        let selectedKeys = willReceiveProps ? undefined : getKeys(props.defaultSelectedKeys);
+        if ('selectedKeys' in props) {
+            selectedKeys = getKeys(props.selectedKeys);
+        }
+        return selectedKeys;
+    }
+
+    getRawExpandedKeys() {
+        if (!this._rawExpandedKeys && ('expandedKeys' in this.props)) {
+            this._rawExpandedKeys = [...this.state.expandedKeys];
+        }
+    }
+
+    getOpenTransitionName() {
+        const props = this.props;
+        let transitionName = props.openTransitionName;
+        const animationName = props.openAnimation;
+        if (!transitionName && typeof animationName === 'string') {
+            transitionName = `${props.prefixCls}-open-${animationName}`;
+        }
+        return transitionName;
+    }
+
+    getDragNodes(treeNode) {
+        const dragNodesKeys = [];
+        const tPArr = treeNode.props.pos.split('-');
+        loopAllChildren(this.props.children, (item, index, pos, newKey) => {
+            const pArr = pos.split('-');
+            if (treeNode.props.pos === pos || tPArr.length < pArr.length && isInclude(tPArr, pArr)) {
+                dragNodesKeys.push(newKey);
+            }
+        });
+        return dragNodesKeys;
+    }
+
+    getExpandedKeys(treeNode, expand) {
+        const key = treeNode.props.eventKey;
+        const expandedKeys = this.state.expandedKeys;
+        const expandedIndex = expandedKeys.indexOf(key);
+        let exKeys;
+        if (expandedIndex > -1 && !expand) {
+            exKeys = [...expandedKeys];
+            exKeys.splice(expandedIndex, 1);
+            return exKeys;
+        }
+        if (expand && expandedKeys.indexOf(key) === -1) {
+            return expandedKeys.concat([key]);
+        }
+    }
+
+    filterTreeNode(treeNode) {
+        const filterTreeNode = this.props.filterTreeNode;
+        if (typeof filterTreeNode !== 'function' || treeNode.props.disabled) {
+            return false;
+        }
+        return filterTreeNode.call(this, treeNode);
+    }
+
+    renderTreeNode(child, index, level = 0) {
+        const pos = `${level}-${index}`;
+        const key = child.key || pos;
+        const state = this.state;
+        const props = this.props;
+
+        // prefer to child's own selectable property if passed
+        let selectable = props.selectable;
+        if (child.props.hasOwnProperty('selectable')) {
+            selectable = child.props.selectable;
+        }
+
+        const cloneProps = {
+            ref: `treeNode-${key}`,
+            root: this,
+            eventKey: key,
+            pos,
+            selectable,
+            loadData: props.loadData,
+            onMouseEnter: props.onMouseEnter,
+            onMouseLeave: props.onMouseLeave,
+            onRightClick: props.onRightClick,
+            prefixCls: props.prefixCls,
+            showLine: props.showLine,
+            showIcon: props.showIcon,
+            draggable: props.draggable,
+            dragOver: state.dragOverNodeKey === key && this.dropPosition === 0,
+            dragOverGapTop: state.dragOverNodeKey === key && this.dropPosition === -1,
+            dragOverGapBottom: state.dragOverNodeKey === key && this.dropPosition === 1,
+            _dropTrigger: this._dropTrigger,
+            expanded: state.expandedKeys.indexOf(key) !== -1,
+            selected: state.selectedKeys.indexOf(key) !== -1,
+            openTransitionName: this.getOpenTransitionName(),
+            openAnimation: props.openAnimation,
+            filterTreeNode: this.filterTreeNode.bind(this),
+        };
+        if (props.checkable) {
+            cloneProps.checkable = props.checkable;
+            if (props.checkStrictly) {
+                if (state.checkedKeys) {
+                    cloneProps.checked = state.checkedKeys.indexOf(key) !== -1 || false;
+                }
+                if (props.checkedKeys && props.checkedKeys.halfChecked) {
+                    cloneProps.halfChecked = props.checkedKeys.halfChecked.indexOf(key) !== -1 || false;
+                } else {
+                    cloneProps.halfChecked = false;
+                }
+            } else {
+                if (this.checkedKeys) {
+                    cloneProps.checked = this.checkedKeys.indexOf(key) !== -1 || false;
+                }
+                cloneProps.halfChecked = this.halfCheckedKeys.indexOf(key) !== -1;
+            }
+        }
+        if (this.treeNodesStates && this.treeNodesStates[pos]) {
+            assign(cloneProps, this.treeNodesStates[pos].siblingPosition);
+        }
+        return React.cloneElement(child, cloneProps);
+    }
+
+    render() {
+        const props = this.props;
+        const domProps = {
+            className: classNames(props.className, props.prefixCls),
+            role: 'tree-node',
+        };
+        if (props.focusable) {
+            domProps.tabIndex = '0';
+            domProps.onKeyDown = this.onKeyDown;
+        }
+        const getTreeNodesStates = () => {
+            this.treeNodesStates = {};
+            loopAllChildren(props.children, (item, index, pos, keyOrPos, siblingPosition) => {
+                this.treeNodesStates[pos] = {
+                    siblingPosition,
+                };
+            });
+        };
+        if (props.showLine && !props.checkable) {
+            getTreeNodesStates();
+        }
+        if (props.checkable && (this.checkedKeysChange || props.loadData)) {
+            if (props.checkStrictly) {
+                getTreeNodesStates();
+            } else if (props._treeNodesStates) {
+                this.treeNodesStates = props._treeNodesStates.treeNodesStates;
+                this.halfCheckedKeys = props._treeNodesStates.halfCheckedKeys;
+                this.checkedKeys = props._treeNodesStates.checkedKeys;
+            } else {
+                const checkedKeys = this.state.checkedKeys;
+                let checkKeys;
+                if (!props.loadData && this.checkKeys && this._checkedKeys &&
+                    arraysEqual(this._checkedKeys, checkedKeys)) {
+                    // if checkedKeys the same as _checkedKeys from onCheck, use _checkedKeys.
+                    checkKeys = this.checkKeys;
+                } else {
+                    const checkedPositions = [];
+                    this.treeNodesStates = {};
+                    loopAllChildren(props.children, (item, index, pos, keyOrPos, siblingPosition) => {
+                        this.treeNodesStates[pos] = {
+                            node: item,
+                            key: keyOrPos,
+                            checked: false,
+                            halfChecked: false,
+                            siblingPosition,
+                        };
+                        if (checkedKeys.indexOf(keyOrPos) !== -1) {
+                            this.treeNodesStates[pos].checked = true;
+                            checkedPositions.push(pos);
+                        }
+                    });
+                    // if the parent node's key exists, it all children node will be checked
+                    handleCheckState(this.treeNodesStates, filterParentPosition(checkedPositions), true);
+                    checkKeys = getCheck(this.treeNodesStates);
+                }
+                this.halfCheckedKeys = checkKeys.halfCheckedKeys;
+                this.checkedKeys = checkKeys.checkedKeys;
+            }
+        }
+
+        return (
+            <ul {...domProps} unselectable ref="tree">
+                {React.Children.map(props.children, this.renderTreeNode, this)}
+            </ul>
+        );
+    }
 }
 
 Tree.propTypes = {
-  prefixCls: PropTypes.string,
-  children: PropTypes.any,
-  showLine: PropTypes.bool,
-  showIcon: PropTypes.bool,
-  selectable: PropTypes.bool,
-  multiple: PropTypes.bool,
-  checkable: PropTypes.oneOfType([
-    PropTypes.bool,
-    PropTypes.node,
-  ]),
-  _treeNodesStates: PropTypes.object,
-  checkStrictly: PropTypes.bool,
-  draggable: PropTypes.bool,
-  autoExpandParent: PropTypes.bool,
-  defaultExpandAll: PropTypes.bool,
-  defaultExpandedKeys: PropTypes.arrayOf(PropTypes.string),
-  expandedKeys: PropTypes.arrayOf(PropTypes.string),
-  defaultCheckedKeys: PropTypes.arrayOf(PropTypes.string),
-  checkedKeys: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.object,
-  ]),
-  defaultSelectedKeys: PropTypes.arrayOf(PropTypes.string),
-  selectedKeys: PropTypes.arrayOf(PropTypes.string),
-  onExpand: PropTypes.func,
-  onCheck: PropTypes.func,
-  onSelect: PropTypes.func,
-  loadData: PropTypes.func,
-  onMouseEnter: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  onRightClick: PropTypes.func,
-  onDragStart: PropTypes.func,
-  onDragEnter: PropTypes.func,
-  onDragOver: PropTypes.func,
-  onDragLeave: PropTypes.func,
-  onDrop: PropTypes.func,
-  onDragEnd: PropTypes.func,
-  filterTreeNode: PropTypes.func,
-  openTransitionName: PropTypes.string,
-  openAnimation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  expandOnDrag: PropTypes.bool,
+    prefixCls: PropTypes.string,
+    children: PropTypes.any,
+    showLine: PropTypes.bool,
+    showIcon: PropTypes.bool,
+    selectable: PropTypes.bool,
+    multiple: PropTypes.bool,
+    checkable: PropTypes.oneOfType([
+        PropTypes.bool,
+        PropTypes.node,
+    ]),
+    _treeNodesStates: PropTypes.object,
+    checkStrictly: PropTypes.bool,
+    draggable: PropTypes.bool,
+    autoExpandParent: PropTypes.bool,
+    defaultExpandAll: PropTypes.bool,
+    defaultExpandedKeys: PropTypes.arrayOf(PropTypes.string),
+    expandedKeys: PropTypes.arrayOf(PropTypes.string),
+    defaultCheckedKeys: PropTypes.arrayOf(PropTypes.string),
+    checkedKeys: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.string),
+        PropTypes.object,
+    ]),
+    defaultSelectedKeys: PropTypes.arrayOf(PropTypes.string),
+    selectedKeys: PropTypes.arrayOf(PropTypes.string),
+    onExpand: PropTypes.func,
+    onCheck: PropTypes.func,
+    onSelect: PropTypes.func,
+    loadData: PropTypes.func,
+    gapHeight: PropTypes.number,
+    onMouseEnter: PropTypes.func,
+    onMouseLeave: PropTypes.func,
+    onRightClick: PropTypes.func,
+    onDragStart: PropTypes.func,
+    onDragEnter: PropTypes.func,
+    onDragOver: PropTypes.func,
+    onDragLeave: PropTypes.func,
+    onDrop: PropTypes.func,
+    onDragEnd: PropTypes.func,
+    filterTreeNode: PropTypes.func,
+    openTransitionName: PropTypes.string,
+    openAnimation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    expandOnDrag: PropTypes.bool,
 };
 
 Tree.defaultProps = {
-  prefixCls: 'rc-tree',
-  showLine: false,
-  showIcon: true,
-  expandOnDrag: true,
-  selectable: true,
-  multiple: false,
-  checkable: false,
-  checkStrictly: false,
-  draggable: false,
-  autoExpandParent: true,
-  defaultExpandAll: false,
-  defaultExpandedKeys: [],
-  defaultCheckedKeys: [],
-  defaultSelectedKeys: [],
-  onExpand: noop,
-  onCheck: noop,
-  onSelect: noop,
-  onDragStart: noop,
-  onDragEnter: noop,
-  onDragOver: noop,
-  onDragLeave: noop,
-  onDrop: noop,
-  onDragEnd: noop,
+    prefixCls: 'rc-tree',
+    showLine: false,
+    showIcon: true,
+    expandOnDrag: true,
+    selectable: true,
+    multiple: false,
+    checkable: false,
+    checkStrictly: false,
+    gapHeight: 25,
+    draggable: false,
+    autoExpandParent: true,
+    defaultExpandAll: false,
+    defaultExpandedKeys: [],
+    defaultCheckedKeys: [],
+    defaultSelectedKeys: [],
+    onExpand: noop,
+    onCheck: noop,
+    onSelect: noop,
+    onDragStart: noop,
+    onDragEnter: noop,
+    onDragOver: noop,
+    onDragLeave: noop,
+    onDrop: noop,
+    onDragEnd: noop,
 };
 
 export default Tree;

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -102,18 +102,14 @@ class Tree extends React.Component {
       dragOverNodeKey: treeNode.props.eventKey,
     };
     let expandedKeys;
-    if(this.props.expandOnDrag)
-    {
+    if (this.props.expandOnDrag) {
       expandedKeys = this.getExpandedKeys(treeNode, true);
       if (expandedKeys) {
         this.getRawExpandedKeys();
         st.expandedKeys = expandedKeys;
       }
-
-    }
-    else{
-       expandedKeys= this.state.expandedKeys;
-
+    } else {
+      expandedKeys = this.state.expandedKeys;
     }
 
     this.setState(st);
@@ -628,13 +624,14 @@ Tree.propTypes = {
   filterTreeNode: PropTypes.func,
   openTransitionName: PropTypes.string,
   openAnimation: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  expandOnDrag: PropTypes.bool,
 };
 
 Tree.defaultProps = {
   prefixCls: 'rc-tree',
   showLine: false,
   showIcon: true,
-  expandOnDrag:true,
+  expandOnDrag: true,
   selectable: true,
   multiple: false,
   checkable: false,

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -159,7 +159,7 @@ class TreeNode extends React.Component {
       switcherCls[`${prefixCls}-center_${expandedState}`] = !props.last;
       switcherCls[`${prefixCls}-bottom_${expandedState}`] = props.last;
     }
-    if (props.disabled) {
+    if (props.disabled && !props.allowExpandOnDisableNode) {
       switcherCls[`${prefixCls}-switcher-disabled`] = true;
       return <span className={classNames(switcherCls)}></span>;
     }
@@ -369,6 +369,7 @@ TreeNode.isTreeNode = 1;
 TreeNode.propTypes = {
   prefixCls: PropTypes.string,
   disabled: PropTypes.bool,
+  allowExpandOnDisableNode:PropTypes.bool,
   disableCheckbox: PropTypes.bool,
   expanded: PropTypes.bool,
   isLeaf: PropTypes.bool,
@@ -378,6 +379,7 @@ TreeNode.propTypes = {
 
 TreeNode.defaultProps = {
   title: defaultTitle,
+  allowExpandOnDisable:false
 };
 
 export default TreeNode;

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -369,7 +369,7 @@ TreeNode.isTreeNode = 1;
 TreeNode.propTypes = {
   prefixCls: PropTypes.string,
   disabled: PropTypes.bool,
-  allowExpandOnDisableNode:PropTypes.bool,
+  allowExpandOnDisableNode: PropTypes.bool,
   disableCheckbox: PropTypes.bool,
   expanded: PropTypes.bool,
   isLeaf: PropTypes.bool,
@@ -379,7 +379,7 @@ TreeNode.propTypes = {
 
 TreeNode.defaultProps = {
   title: defaultTitle,
-  allowExpandOnDisable:false
+  allowExpandOnDisable: false,
 };
 
 export default TreeNode;

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -121,7 +121,39 @@ describe('Tree', () => {
       expect(handleExpand).toBeCalledWith([], { expanded: false, node });
     });
   });
+  it('fires expand event event on disabled node', () => {
+    const handleExpand = jest.fn();
+    const wrapper = mount(
+      <Tree onExpand={handleExpand}>
+        <TreeNode title="parent 1" key="0-0" disabled allowExpandOnDisableNode={true}>
+          <TreeNode title="leaf 1" key="0-0-0" />
+        </TreeNode>
+      </Tree>
+    );
+    const switcher = wrapper.find('.rc-tree-switcher');
+    const node = wrapper.find(TreeNode).first().node;
 
+    switcher.simulate('click');
+    expect(handleExpand).toBeCalledWith(['0-0'], { expanded: true, node });
+
+    switcher.simulate('click');
+    expect(handleExpand).toBeCalledWith([], { expanded: false, node });
+  });
+  it('it does not fire expand event event on disabled node', () => {
+    const handleExpand = jest.fn();
+    const wrapper = mount(
+      <Tree onExpand={handleExpand}>
+        <TreeNode title="parent 1" key="0-0" disabled allowExpandOnDisableNode={false}>
+          <TreeNode title="leaf 1" key="0-0-0" />
+        </TreeNode>
+      </Tree>
+    );
+    const switcher = wrapper.find('.rc-tree-switcher');
+
+    switcher.simulate('click');
+    expect(handleExpand).not.toHaveBeenCalled();
+
+  });
   describe('check', () => {
     it('checks default checked keys', () => {
       const wrapper = mount(

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -125,7 +125,7 @@ describe('Tree', () => {
     const handleExpand = jest.fn();
     const wrapper = mount(
       <Tree onExpand={handleExpand}>
-        <TreeNode title="parent 1" key="0-0" disabled allowExpandOnDisableNode={true}>
+        <TreeNode title="parent 1" key="0-0" disabled allowExpandOnDisableNode>
           <TreeNode title="leaf 1" key="0-0-0" />
         </TreeNode>
       </Tree>
@@ -143,7 +143,7 @@ describe('Tree', () => {
     const handleExpand = jest.fn();
     const wrapper = mount(
       <Tree onExpand={handleExpand}>
-        <TreeNode title="parent 1" key="0-0" disabled allowExpandOnDisableNode={false}>
+        <TreeNode title="parent 1" key="0-0" disabled>
           <TreeNode title="leaf 1" key="0-0-0" />
         </TreeNode>
       </Tree>
@@ -152,7 +152,6 @@ describe('Tree', () => {
 
     switcher.simulate('click');
     expect(handleExpand).not.toHaveBeenCalled();
-
   });
   describe('check', () => {
     it('checks default checked keys', () => {


### PR DESCRIPTION
I had the same requirement as the follow issue ticket  : https://github.com/react-component/tree/issues/83 which is why I added a new property to the TreeNode to allow override of the current logic to handle disable nodes.

Additionally, when dragging at times over a  nested tree the nodes would automatically expand. That becomes an issue when having a long nested tree becomes slightly hard to drag from the top to the bottom.  I decided to add a flag which disables/allows this functionality

My changes are meant to keep existing functionality while giving the ability to switch on/off 