### PR TITLE
Recalculate checkedPositions for draggable trees

### DIFF
--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -582,6 +582,7 @@ class Tree extends React.Component {
       let checkKeys;
       if (
         !props.loadData &&
+          !props.draggable &&
           this.checkKeys &&
           this._checkedKeys &&
           arraysEqual(this._checkedKeys, checkedKeys)


### PR DESCRIPTION
This PR ensures that the positions of a checked nodes are recalculated on every render if the tree is draggable.

This is needed as the checked keys may not change when dragging a node, but the positions do change.

fixes #117