### PR TITLE
Added support for clicking label to check the checkbox

### DIFF
--- a/examples/basic-controlled.js
+++ b/examples/basic-controlled.js
@@ -102,6 +102,11 @@ const Demo = React.createClass({
       checkedKeys: [`0-0-${parseInt(Math.random() * 3, 10)}-key`],
     });
   },
+  toggleCheckOnSelect() {
+    this.setState({
+      checkOnSelect: !this.state.checkOnSelect,
+    });
+  },
   render() {
     const loop = data => {
       return data.map((item) => {
@@ -141,6 +146,7 @@ const Demo = React.createClass({
       <h2>controlled</h2>
       <Tree
         checkable
+        checkOnSelect={this.state.checkOnSelect}
         onExpand={this.onExpand} expandedKeys={this.state.expandedKeys}
         autoExpandParent={this.state.autoExpandParent}
         onCheck={this.onCheck} checkedKeys={this.state.checkedKeys}
@@ -149,6 +155,9 @@ const Demo = React.createClass({
         {loop(gData)}
       </Tree>
       <button onClick={this.triggerChecked}>trigger checked</button>
+      <button onClick={this.toggleCheckOnSelect}>
+        toggle checkOnSelect ({`${this.state.checkOnSelect}`})
+      </button>
 
       <h2>checkStrictly</h2>
       <Tree

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -322,6 +322,11 @@ class Tree extends React.Component {
     const eventKey = treeNode.props.eventKey;
     const selected = !treeNode.props.selected;
 
+    if (props.checkable) {
+      this.onCheck(treeNode);
+      return;
+    }
+
     let selectedKeys = [...state.selectedKeys];
     if (!selected) {
       const index = selectedKeys.indexOf(eventKey);

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -31,6 +31,7 @@ class Tree extends React.Component {
       PropTypes.bool,
       PropTypes.node,
     ]),
+    checkOnSelect: PropTypes.bool,
     checkStrictly: PropTypes.bool,
     draggable: PropTypes.bool,
     autoExpandParent: PropTypes.bool,
@@ -71,6 +72,7 @@ class Tree extends React.Component {
     selectable: true,
     multiple: false,
     checkable: false,
+    checkOnSelect: false,
     checkStrictly: false,
     draggable: false,
     autoExpandParent: true,
@@ -322,9 +324,8 @@ class Tree extends React.Component {
     const eventKey = treeNode.props.eventKey;
     const selected = !treeNode.props.selected;
 
-    if (props.checkable) {
+    if (props.checkable && props.checkOnSelect) {
       this.onCheck(treeNode);
-      return;
     }
 
     let selectedKeys = [...state.selectedKeys];

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -255,42 +255,83 @@ describe('Tree', () => {
       });
     });
 
-    it('fires check event if clicking label', () => {
-      const handleCheck = jest.fn();
-      const wrapper = mount(
-        <Tree checkable onCheck={handleCheck}>
-          <TreeNode title="parent 1" key="0-0">
-            <TreeNode title="leaf 1" key="0-0-0" />
-          </TreeNode>
-        </Tree>
-      );
-      wrapper.find('.rc-tree-switcher').simulate('click');
-      const treeNode1 = wrapper.find(TreeNode).first();
-      const treeNode2 = wrapper.find(TreeNode).last();
-      const treeElm1 = wrapper.find(Tree).props().children;
-      const treeElm2 = treeNode1.props().children;
+    describe('checkOnSelect', () => {
+      it('fires check event if checkOnSelect === true', () => {
+        const handleCheck = jest.fn();
+        const wrapper = mount(
+          <Tree checkable checkOnSelect onCheck={handleCheck}>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+            </TreeNode>
+          </Tree>
+        );
+        wrapper.find('.rc-tree-switcher').simulate('click');
+        const treeNode1 = wrapper.find(TreeNode).first();
+        const treeNode2 = wrapper.find(TreeNode).last();
+        const treeElm1 = wrapper.find(Tree).props().children;
+        const treeElm2 = treeNode1.props().children;
 
-      wrapper.find('.rc-tree-node-content-wrapper').first().simulate('click');
-      expect(handleCheck).toBeCalledWith(['0-0-0', '0-0'], {
-        checked: true,
-        checkedNodes: [treeElm2, treeElm1],
-        checkedNodesPositions: [
-          { node: treeElm2, pos: '0-0-0' },
-          { node: treeElm1, pos: '0-0' },
-        ],
-        event: 'check',
-        halfCheckedKeys: [],
-        node: treeNode1.node,
+        wrapper.find('.rc-tree-node-content-wrapper').first().simulate('click');
+        expect(handleCheck).toBeCalledWith(['0-0-0', '0-0'], {
+          checked: true,
+          checkedNodes: [treeElm2, treeElm1],
+          checkedNodesPositions: [
+            { node: treeElm2, pos: '0-0-0' },
+            { node: treeElm1, pos: '0-0' },
+          ],
+          event: 'check',
+          halfCheckedKeys: [],
+          node: treeNode1.node,
+        });
+
+        wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
+        expect(handleCheck).toBeCalledWith([], {
+          checked: false,
+          checkedNodes: [],
+          checkedNodesPositions: [],
+          event: 'check',
+          halfCheckedKeys: [],
+          node: treeNode2.node,
+        });
       });
 
-      wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
-      expect(handleCheck).toBeCalledWith([], {
-        checked: false,
-        checkedNodes: [],
-        checkedNodesPositions: [],
-        event: 'check',
-        halfCheckedKeys: [],
-        node: treeNode2.node,
+      it('does not fires check event if checkOnSelect !== true', () => {
+        const handleCheck = jest.fn();
+        const wrapper = mount(
+          <Tree checkable onCheck={handleCheck}>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+            </TreeNode>
+          </Tree>
+        );
+        wrapper.find('.rc-tree-switcher').simulate('click');
+        const treeNode1 = wrapper.find(TreeNode).first();
+        const treeNode2 = wrapper.find(TreeNode).last();
+        const treeElm1 = wrapper.find(Tree).props().children;
+        const treeElm2 = treeNode1.props().children;
+
+        wrapper.find('.rc-tree-node-content-wrapper').first().simulate('click');
+        expect(handleCheck).not.toBeCalledWith(['0-0-0', '0-0'], {
+          checked: true,
+          checkedNodes: [treeElm2, treeElm1],
+          checkedNodesPositions: [
+            { node: treeElm2, pos: '0-0-0' },
+            { node: treeElm1, pos: '0-0' },
+          ],
+          event: 'check',
+          halfCheckedKeys: [],
+          node: treeNode1.node,
+        });
+
+        wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
+        expect(handleCheck).not.toBeCalledWith([], {
+          checked: false,
+          checkedNodes: [],
+          checkedNodesPositions: [],
+          event: 'check',
+          halfCheckedKeys: [],
+          node: treeNode2.node,
+        });
       });
     });
 

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -255,6 +255,45 @@ describe('Tree', () => {
       });
     });
 
+    it('fires check event if clicking label', () => {
+      const handleCheck = jest.fn();
+      const wrapper = mount(
+        <Tree checkable onCheck={handleCheck}>
+          <TreeNode title="parent 1" key="0-0">
+            <TreeNode title="leaf 1" key="0-0-0" />
+          </TreeNode>
+        </Tree>
+      );
+      wrapper.find('.rc-tree-switcher').simulate('click');
+      const treeNode1 = wrapper.find(TreeNode).first();
+      const treeNode2 = wrapper.find(TreeNode).last();
+      const treeElm1 = wrapper.find(Tree).props().children;
+      const treeElm2 = treeNode1.props().children;
+
+      wrapper.find('.rc-tree-node-content-wrapper').first().simulate('click');
+      expect(handleCheck).toBeCalledWith(['0-0-0', '0-0'], {
+        checked: true,
+        checkedNodes: [treeElm2, treeElm1],
+        checkedNodesPositions: [
+          { node: treeElm2, pos: '0-0-0' },
+          { node: treeElm1, pos: '0-0' },
+        ],
+        event: 'check',
+        halfCheckedKeys: [],
+        node: treeNode1.node,
+      });
+
+      wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
+      expect(handleCheck).toBeCalledWith([], {
+        checked: false,
+        checkedNodes: [],
+        checkedNodesPositions: [],
+        event: 'check',
+        halfCheckedKeys: [],
+        node: treeNode2.node,
+      });
+    });
+
     // https://github.com/react-component/tree/issues/117
     it('check works correctly after dragging children under another node', () => {
       const wrapper = mount(


### PR DESCRIPTION
It easy to miss the click on checkbox. Because of that, it is an established UI/UX behavior to check checkbox when clicking its label also. I added `checkOnSelect` flag that will introduce that behavior.

In general, I think it is a bad feature of having having selectable and checkable being used together but I didnt want to break backwards compatibility so I implemented a flag.

However, I dont think anyone should be allowed to check and select same node separately. That is a very confusing UX and if core team agrees with this, I can remove flag and default check to be triggered when `checkable` is used and clicking label. 