### PR TITLE
Fix warning with latest react

### DIFF
--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -581,7 +581,7 @@ class Tree extends React.Component {
         {...domProps}
         className={className}
         role="tree-node"
-        unselectable
+        unselectable="on"
       >
         {React.Children.map(props.children, this.renderTreeNode, this)}
       </ul>

--- a/tests/__snapshots__/Tree.spec.js.snap
+++ b/tests/__snapshots__/Tree.spec.js.snap
@@ -3,7 +3,7 @@ exports[`Tree renders correctly 1`] = `
   class="rc-tree forTest rc-tree-show-line"
   role="tree-node"
   tabindex="0"
-  unselectable="true">
+  unselectable="on">
   <li
     class="spe">
     <span
@@ -104,7 +104,7 @@ exports[`Tree renders opaque children correctly 1`] = `
 <ul
   class="rc-tree"
   role="tree-node"
-  unselectable="true">
+  unselectable="on">
   <li
     class="">
     <span


### PR DESCRIPTION
`Received 'true' for non-boolean attribute 'unselectable'. If this is expected, cast the value to a string.`