### PR TITLE
Pass nativeEvent to the event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ see examples
 |defaultSelectedKeys | default selected treeNodes | String[] | [] |
 |icon | customize icon. When you pass component, whose render will receive full TreeNode props as component props | element/Function(props) | - |
 |selectedKeys | Controlled selected treeNodes(After setting, defaultSelectedKeys will not work) | String[] | [] |
-|onExpand | fire on treeNode expand or not | function(expandedKeys, {expanded: bool, node}) | - |
-|onCheck | click the treeNode/checkbox to fire | function(checkedKeys, e:{checked: bool, checkedNodes, node, event}) | - |
-|onSelect | click the treeNode to fire | function(selectedKeys, e:{selected: bool, selectedNodes, node, event}) | - |
+|onExpand | fire on treeNode expand or not | function(expandedKeys, {expanded: bool, node, nativeEvent}) | - |
+|onCheck | click the treeNode/checkbox to fire | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, nativeEvent}) | - |
+|onSelect | click the treeNode to fire | function(selectedKeys, e:{selected: bool, selectedNodes, node, event, nativeEvent}) | - |
 |filterTreeNode | filter some treeNodes as you need. it should return true | function(node) | - |
 |loadData | load data asynchronously and the return value should be a promise | function(node) | - |
 |onRightClick | select current treeNode and show customized contextmenu | function({event,node}) | - |

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -402,6 +402,7 @@ class Tree extends React.Component {
         selected: targetSelected,
         node: treeNode,
         selectedNodes,
+        nativeEvent: e.nativeEvent,
       };
       onSelect(selectedKeys, eventObj);
     }

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -439,7 +439,7 @@ class Tree extends React.Component {
    * When top `onCheckConductFinished` called, will execute all batch update.
    * And trigger `onCheck` event.
    */
-  onCheckConductFinished = () => {
+  onCheckConductFinished = (e) => {
     const { checkedKeys, halfCheckedKeys } = this.state;
     const { onCheck, checkStrictly, children } = this.props;
 
@@ -469,6 +469,7 @@ class Tree extends React.Component {
       event: 'check',
       node: this.checkedBatch.treeNode,
       checked: this.checkedBatch.checked,
+      nativeEvent: e.nativeEvent,
     };
 
     if (checkStrictly) {

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -534,7 +534,11 @@ class Tree extends React.Component {
     this.setUncontrolledState({ expandedKeys });
 
     if (onExpand) {
-      onExpand(expandedKeys, { node: treeNode, expanded: targetExpanded });
+      onExpand(expandedKeys, {
+        node: treeNode,
+        expanded: targetExpanded,
+        nativeEvent: e.nativeEvent,
+      });
     }
 
     // Async Load data

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -89,7 +89,7 @@ class TreeNode extends React.Component {
     this.syncLoadData(nextProps);
   }
 
-  onUpCheckConduct = (treeNode, nodeChecked, nodeHalfChecked) => {
+  onUpCheckConduct = (treeNode, nodeChecked, nodeHalfChecked, e) => {
     const { pos: nodePos } = treeNode.props;
     const { eventKey, pos, checked, halfChecked } = this.props;
     const {
@@ -99,7 +99,7 @@ class TreeNode extends React.Component {
 
     // Stop conduct when current node is disabled
     if (isCheckDisabled(this)) {
-      onCheckConductFinished();
+      onCheckConductFinished(e);
       return;
     }
 
@@ -135,14 +135,14 @@ class TreeNode extends React.Component {
       onBatchNodeCheck(eventKey, nextChecked, nextHalfChecked);
 
       if (onUpCheckConduct) {
-        onUpCheckConduct(this, nextChecked, nextHalfChecked);
+        onUpCheckConduct(this, nextChecked, nextHalfChecked, e);
       } else {
         // Flush all the update
-        onCheckConductFinished();
+        onCheckConductFinished(e);
       }
     } else {
       // Flush all the update
-      onCheckConductFinished();
+      onCheckConductFinished(e);
     }
   };
 
@@ -196,9 +196,9 @@ class TreeNode extends React.Component {
 
     // Parent conduct
     if (onUpCheckConduct) {
-      onUpCheckConduct(this, targetChecked, false);
+      onUpCheckConduct(this, targetChecked, false, e);
     } else {
-      onCheckConductFinished();
+      onCheckConductFinished(e);
     }
   };
 

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -268,6 +268,7 @@ describe('Tree', () => {
         event: 'check',
         halfCheckedKeys: [],
         node: treeNode1.instance(),
+        nativeEvent: expect.objectContaining({}),
       });
 
       wrapper.find('.rc-tree-checkbox').last().simulate('click');
@@ -278,6 +279,7 @@ describe('Tree', () => {
         event: 'check',
         halfCheckedKeys: [],
         node: treeNode2.instance(),
+        nativeEvent: expect.objectContaining({}),
       });
     });
 
@@ -604,6 +606,7 @@ describe('Tree', () => {
         event: 'check',
         halfCheckedKeys: [],
         node: treeNode1.instance(),
+        nativeEvent: expect.objectContaining({}),
       });
 
       wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
@@ -614,6 +617,7 @@ describe('Tree', () => {
         event: 'check',
         halfCheckedKeys: [],
         node: treeNode2.instance(),
+        nativeEvent: expect.objectContaining({}),
       });
     });
   });

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -140,10 +140,18 @@ describe('Tree', () => {
       const node = wrapper.find(TreeNode).instance();
 
       switcher.simulate('click');
-      expect(handleExpand).toBeCalledWith(['0-0'], { expanded: true, node });
+      expect(handleExpand).toBeCalledWith(['0-0'], {
+        expanded: true,
+        node,
+        nativeEvent: expect.objectContaining({}),
+      });
 
       switcher.simulate('click');
-      expect(handleExpand).toBeCalledWith([], { expanded: false, node });
+      expect(handleExpand).toBeCalledWith([], {
+        expanded: false,
+        node,
+        nativeEvent: expect.objectContaining({}),
+      });
     });
   });
 

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -562,6 +562,7 @@ describe('Tree', () => {
         node,
         selected: true,
         selectedNodes: [nodeElm],
+        nativeEvent: expect.objectContaining({}),
       });
 
       nodeContent.simulate('click');
@@ -570,6 +571,7 @@ describe('Tree', () => {
         node,
         selected: false,
         selectedNodes: [],
+        nativeEvent: expect.objectContaining({}),
       });
     });
   });

--- a/tests/TreeProps.spec.js
+++ b/tests/TreeProps.spec.js
@@ -134,6 +134,7 @@ describe('Tree Props', () => {
         selected: true,
         node: targetNode.instance(),
         selectedNodes: [parentNode.props().children],
+        nativeEvent: expect.objectContaining({}),
       });
       handleOnSelect.mockReset();
 
@@ -144,6 +145,7 @@ describe('Tree Props', () => {
         selected: false,
         node: targetNode.instance(),
         selectedNodes: [],
+        nativeEvent: expect.objectContaining({}),
       });
       handleOnSelect.mockReset();
 
@@ -154,6 +156,7 @@ describe('Tree Props', () => {
         selected: true,
         node: targetNode.instance(),
         selectedNodes: [parentNode.props().children],
+        nativeEvent: expect.objectContaining({}),
       });
       handleOnSelect.mockReset();
 
@@ -163,6 +166,7 @@ describe('Tree Props', () => {
         selected: true,
         node: parentNode.instance(),
         selectedNodes: [withSelectable.find(Tree).props().children],
+        nativeEvent: expect.objectContaining({}),
       });
     });
   });
@@ -196,6 +200,7 @@ describe('Tree Props', () => {
       selected: true,
       node: targetNode.instance(),
       selectedNodes: [parentNode.props().children],
+      nativeEvent: expect.objectContaining({}),
     });
     handleOnSelect.mockReset();
 
@@ -206,6 +211,7 @@ describe('Tree Props', () => {
       selected: true,
       node: parentNode.instance(),
       selectedNodes: [wrapper.find(Tree).props().children, parentNode.props().children],
+      nativeEvent: expect.objectContaining({}),
     }));
     handleOnSelect.mockReset();
 
@@ -216,6 +222,7 @@ describe('Tree Props', () => {
       selected: false,
       node: targetNode.instance(),
       selectedNodes: [wrapper.find(Tree).props().children],
+      nativeEvent: expect.objectContaining({}),
     });
   });
 
@@ -251,6 +258,7 @@ describe('Tree Props', () => {
         selected: true,
         node: targetNode.instance(),
         selectedNodes: [parentNode.props().children],
+        nativeEvent: expect.objectContaining({}),
       });
       expect(handleOnCheck).not.toBeCalled();
       expect(handleOnSelect).toBeCalled();

--- a/tests/TreeProps.spec.js
+++ b/tests/TreeProps.spec.js
@@ -274,6 +274,7 @@ describe('Tree Props', () => {
         checked: true,
         node: targetNode.instance(),
         checkedNodes: [withCheckable.find(Tree).props().children, parentNode.props().children],
+        nativeEvent: expect.objectContaining({}),
       }));
       expect(handleOnSelect).not.toBeCalled();
     });
@@ -309,6 +310,7 @@ describe('Tree Props', () => {
         checked: true,
         node: targetNode.instance(),
         checkedNodes: [withCheckable.find(Tree).props().children, parentNode.props().children],
+        nativeEvent: expect.objectContaining({}),
       }));
       expect(handleOnSelect).not.toBeCalled();
     });
@@ -347,6 +349,7 @@ describe('Tree Props', () => {
       checked: true,
       node: targetNode.instance(),
       checkedNodes: [parentNode.props().children],
+      nativeEvent: expect.objectContaining({}),
     }));
   });
 


### PR DESCRIPTION
For [dir tree requirement](https://github.com/ant-design/ant-design/issues/7749), interactive operation need additional key press(e.g. ctrl, shift) which need native event info.