### PR TITLE
Render data- and aria- attributes

### DIFF
--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -8,6 +8,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import { treeContextTypes } from './contextTypes';
 import {
   convertTreeToEntities, convertDataToTree,
+  getDataAndAria,
   getPosition, getDragNodesKeys,
   parseCheckedKeys,
   conductExpandParent, calcSelectedKeys,
@@ -672,7 +673,7 @@ class Tree extends React.Component {
       prefixCls, className, focusable,
       showLine, tabIndex = 0,
     } = this.props;
-    const domProps = {};
+    const domProps = getDataAndAria(this.props);
 
     if (focusable) {
       domProps.tabIndex = tabIndex;

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -6,7 +6,9 @@ import toArray from 'rc-util/lib/Children/toArray';
 import { polyfill } from 'react-lifecycles-compat';
 import { nodeContextTypes } from './contextTypes';
 import {
-  getNodeChildren, mapChildren,
+  getNodeChildren,
+  getDataAndAria,
+  mapChildren,
   warnOnlyTreeNode,
 } from './util';
 
@@ -475,12 +477,7 @@ class TreeNode extends React.Component {
       draggable,
     } } = this.context;
     const disabled = this.isDisabled();
-    const dataOrAriaAttributeProps = Object.keys(otherProps).reduce((prev, key) => {
-      if ((key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-')) {
-        prev[key] = otherProps[key];
-      }
-      return prev;
-    }, {});
+    const dataOrAriaAttributeProps = getDataAndAria(otherProps);
 
     return (
       <li

--- a/src/util.js
+++ b/src/util.js
@@ -427,3 +427,16 @@ export function conductExpandParent(keyList, keyEntities) {
 
   return Object.keys(expandedKeys);
 }
+
+/**
+ * Returns only the data- and aria- key/value pairs
+ * @param {object} props 
+ */
+export function getDataAndAria(props) {
+  return Object.keys(props).reduce((prev, key) => {
+    if ((key.substr(0, 5) === 'data-' || key.substr(0, 5) === 'aria-')) {
+      prev[key] = props[key];
+    }
+    return prev;
+  }, {});
+}

--- a/tests/TreeProps.spec.js
+++ b/tests/TreeProps.spec.js
@@ -654,4 +654,16 @@ describe('Tree Props', () => {
     const { animation } = wrapper.find(Animate).props();
     expect(animation).toEqual(openAnimation);
   });
+
+  describe('data and aria props', () => {
+    it('renders data attributes', () => {
+      const wrapper = render(<Tree data-test="tree" />);
+      expect(renderToJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('renders aria attributes', () => {
+      const wrapper = render(<Tree aria-label="name" />);
+      expect(renderToJson(wrapper)).toMatchSnapshot();
+    });
+  });
 });

--- a/tests/__snapshots__/TreeProps.spec.js.snap
+++ b/tests/__snapshots__/TreeProps.spec.js.snap
@@ -189,6 +189,24 @@ exports[`Tree Props checkable without selectable 1`] = `
 </ul>
 `;
 
+exports[`Tree Props data and aria props renders aria attributes 1`] = `
+<ul
+  aria-label="name"
+  class="rc-tree"
+  role="tree"
+  unselectable="on"
+/>
+`;
+
+exports[`Tree Props data and aria props renders data attributes 1`] = `
+<ul
+  class="rc-tree"
+  data-test="tree"
+  role="tree"
+  unselectable="on"
+/>
+`;
+
 exports[`Tree Props defaultExpandAll 1`] = `
 <ul
   class="rc-tree"

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -7,6 +7,7 @@ import {
   convertDataToTree, convertTreeToEntities,
   conductCheck, conductExpandParent,
   getDragNodesKeys,
+  getDataAndAria,
 } from '../src/util';
 import { convertTreeToData } from './util';
 
@@ -215,5 +216,20 @@ describe('Util', () => {
     const treeNode1 = tree.find(TreeNode).at(1).instance();
     const keys1 = getDragNodesKeys(treeNode1.props.children, treeNode1);
     expect(keys1.sort()).toEqual(['111', '222', '333'].sort());
+  });
+
+  describe('getDataAndAria', () => {
+    it('should return only data- and aria- properties', () => {
+      const props = {
+        'data-test': 'name',
+        'aria-label': 'name',
+        dataSource: '/api',
+        ariaLabel: 'some-label',
+      };
+      expect(getDataAndAria(props)).toEqual({
+        'data-test': 'name',
+        'aria-label': 'name',
+      });
+    });
   });
 });


### PR DESCRIPTION
Same premise as https://github.com/react-component/tree/pull/172, except this one is for Tree.jsx.

This PR passes `data-` and `aria-` props to the root `<ul>`.