### PR TITLE
Internal store treeNodes ref

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -48,6 +48,13 @@ class Demo extends React.Component {
   onSelect = (selectedKeys, info) => {
     console.log('selected', selectedKeys, info);
     this.selKey = info.node.props.eventKey;
+
+    if (this.tree) {
+      console.log(
+        'Selected DOM node:',
+        selectedKeys.map(key => ReactDOM.findDOMNode(this.tree.domTreeNodes[key])),
+      );
+    }
   };
   onCheck = (checkedKeys, info) => {
     console.log('onCheck', checkedKeys, info);
@@ -62,6 +69,9 @@ class Demo extends React.Component {
       return;
     }
     e.stopPropagation();
+  };
+  setTreeRef = (tree) => {
+    this.tree = tree;
   };
   render() {
     const customLabel = (
@@ -80,6 +90,7 @@ class Demo extends React.Component {
       <div style={{ margin: '0 20px' }}>
         <h2>simple</h2>
         <Tree
+          ref={this.setTreeRef}
           className="myCls" showLine checkable defaultExpandAll
           defaultExpandedKeys={this.state.defaultExpandedKeys}
           onExpand={this.onExpand}

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -93,19 +93,26 @@ class Tree extends React.Component {
     defaultSelectedKeys: [],
   };
 
-  state = {
-    // TODO: Remove this eslint
-    posEntities: {}, // eslint-disable-line react/no-unused-state
-    keyEntities: {},
+  constructor(props) {
+    super(props);
 
-    selectedKeys: [],
-    checkedKeys: [],
-    halfCheckedKeys: [],
-    loadedKeys: [],
-    loadingKeys: [],
-
-    treeNode: [],
-  };
+    this.state = {
+      // TODO: Remove this eslint
+      posEntities: {}, // eslint-disable-line react/no-unused-state
+      keyEntities: {},
+  
+      selectedKeys: [],
+      checkedKeys: [],
+      halfCheckedKeys: [],
+      loadedKeys: [],
+      loadingKeys: [],
+  
+      treeNode: [],
+    };
+  
+    // Internal usage for `rc-tree-select`, we don't promise it will not change.
+    this.domTreeNodes = {};
+  }
 
   getChildContext() {
     const {
@@ -151,6 +158,8 @@ class Tree extends React.Component {
         onNodeDragLeave: this.onNodeDragLeave,
         onNodeDragEnd: this.onNodeDragEnd,
         onNodeDrop: this.onNodeDrop,
+
+        registerTreeNode: this.registerTreeNode,
       },
     };
   }
@@ -634,6 +643,14 @@ class Tree extends React.Component {
 
     if (needSync) {
       this.setState(newState);
+    }
+  };
+
+  registerTreeNode = (key, node) => {
+    if (node) {
+      this.domTreeNodes[key] = node;
+    } else {
+      delete this.domTreeNodes[key];
     }
   };
 

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -508,7 +508,6 @@ class TreeNode extends React.Component {
 
     return (
       <li
-        ref={this.setRef}
         className={classNames(className, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -76,11 +76,22 @@ class TreeNode extends React.Component {
 
   // Isomorphic needn't load data in server side
   componentDidMount() {
+    const { eventKey } = this.props;
+    const { rcTree: { registerTreeNode } } = this.context;
+
     this.syncLoadData(this.props);
+
+    registerTreeNode(eventKey, this);
   }
 
   componentDidUpdate() {
     this.syncLoadData(this.props);
+  }
+
+  componentWillUnmount() {
+    const { eventKey } = this.props;
+    const { rcTree: { registerTreeNode } } = this.context;
+    registerTreeNode(eventKey, null);
   }
 
   onSelectorClick = (e) => {
@@ -497,6 +508,7 @@ class TreeNode extends React.Component {
 
     return (
       <li
+        ref={this.setRef}
         className={classNames(className, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -957,4 +957,20 @@ describe('Tree Basic', () => {
       expect(wrapper.render()).toMatchSnapshot();
     });
   });
+
+  it('get treeNode ref', () => {
+    const wrapper = mount(
+      <Tree defaultExpandAll>
+        <TreeNode key="00" title="00" />
+        <TreeNode key="01" title="01">
+          <TreeNode key="010" title="010" />
+          <TreeNode key="012" title="012" />
+        </TreeNode>
+      </Tree>
+    );
+
+    expect(
+      Object.keys(wrapper.instance().domTreeNodes)
+    ).toHaveLength(4);
+  });
 });


### PR DESCRIPTION
Internal store ref to enable `rc-tree-select` to find the selected DOM node.

ref: https://github.com/ant-design/ant-design/issues/14897