### PR TITLE
Tree and TreeNode fixes for the material theme.

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -44,12 +44,13 @@
     }
     ul {
       margin: 0;
-      padding: 0 0 0 18px;
+      padding: 0;
     }
     .@{treePrefixCls}-node-content-wrapper {
       display: inline-block;
       padding: 1px 3px 0 0;
       margin: 0;
+      width: 100%;
       cursor: pointer;
       height: 17px;
       text-decoration: none;
@@ -141,12 +142,12 @@
       > ul {
         background: url('data:image/gif;base64,R0lGODlhCQACAIAAAMzMzP///yH5BAEAAAEALAAAAAAJAAIAAAIEjI9pUAA7') 0 0 repeat-y;
       }
-      > .@{treePrefixCls}-switcher-noop {
+      > span > .@{treePrefixCls}-switcher-noop {
         background-position: -56px -18px;
       }
     }
     li:last-child {
-      > .@{treePrefixCls}-switcher-noop {
+      > span > .@{treePrefixCls}-switcher-noop {
         background-position: -56px -36px;
       }
     }
@@ -165,7 +166,7 @@
       cursor: not-allowed;
     }
   }
-  &-node-selected {
+  &-node-title-selected {
     background-color: #ffe6b0;
     border: 1px #ffb951 solid;
     opacity: 0.8;

--- a/src/Tree.jsx
+++ b/src/Tree.jsx
@@ -30,6 +30,7 @@ class Tree extends React.Component {
     className: PropTypes.string,
     style: PropTypes.object,
     tabIndex: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    nodePadding: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     children: PropTypes.any,
     treeData: PropTypes.array, // Generate treeNode by children
     showLine: PropTypes.bool,
@@ -88,6 +89,7 @@ class Tree extends React.Component {
     disabled: false,
     checkStrictly: false,
     draggable: false,
+    nodePadding: 18,
     defaultExpandParent: true,
     autoExpandParent: false,
     defaultExpandAll: false,
@@ -124,6 +126,7 @@ class Tree extends React.Component {
       showIcon,
       icon,
       draggable,
+      nodePadding,
       checkable,
       checkStrictly,
       disabled,
@@ -143,6 +146,7 @@ class Tree extends React.Component {
         icon,
         switcherIcon,
         draggable,
+        nodePadding,
         checkable,
         checkStrictly,
         disabled,
@@ -690,7 +694,7 @@ class Tree extends React.Component {
    * [Legacy] Original logic use `key` as tracking clue.
    * We have to use `cloneElement` to pass `key`.
    */
-  renderTreeNode = (child, index, level = 0) => {
+  renderTreeNode = (child, index, pos, level = 0) => {
     const {
       keyEntities,
       expandedKeys = [],
@@ -700,8 +704,9 @@ class Tree extends React.Component {
       loadingKeys = [],
       dragOverNodeKey,
       dropPosition,
+      nodePadding,
     } = this.state;
-    const pos = getPosition(level, index);
+    pos = getPosition(pos, index);
     const key = child.key || pos;
 
     if (!keyEntities[key]) {
@@ -709,6 +714,7 @@ class Tree extends React.Component {
       return null;
     }
 
+    const padding = nodePadding === undefined ? Tree.defaultProps.nodePadding: nodePadding;
     return React.cloneElement(child, {
       key,
       eventKey: key,
@@ -719,11 +725,12 @@ class Tree extends React.Component {
       checked: this.isKeyChecked(key),
       halfChecked: halfCheckedKeys.indexOf(key) !== -1,
       pos,
-
+      level,
+      nodePadding: padding,
       // [Legacy] Drag props
       dragOver: dragOverNodeKey === key && dropPosition === 0,
       dragOverGapTop: dragOverNodeKey === key && dropPosition === -1,
-      dragOverGapBottom: dragOverNodeKey === key && dropPosition === 1,
+      dragOverGapBottom: dragOverNodeKey === key && dropPosition === 1
     });
   };
 
@@ -741,13 +748,15 @@ class Tree extends React.Component {
       <ul
         {...domProps}
         className={classNames(prefixCls, className, {
-          [`${prefixCls}-show-line`]: showLine,
+          [`${prefixCls}-show-line`]: showLine
         })}
         style={style}
         role="tree"
         unselectable="on"
       >
-        {mapChildren(treeNode, (node, index) => this.renderTreeNode(node, index))}
+        {mapChildren(treeNode, (node, index) =>
+          this.renderTreeNode(node, index, index)
+        )}
       </ul>
     );
   }

--- a/src/TreeNode.jsx
+++ b/src/TreeNode.jsx
@@ -472,7 +472,8 @@ class TreeNode extends React.Component {
           `${wrapClass}`,
           `${wrapClass}-${this.getNodeState() || "normal"}`,
           isSelected && `${prefixCls}-node-selected`,
-          !disabled && draggable && "draggable"
+          !disabled && draggable && "draggable",
+          disabled && `${wrapClass}-disabled`
         )}
         draggable={(!disabled && draggable) || undefined}
         aria-grabbed={(!disabled && draggable) || undefined}


### PR DESCRIPTION
Hello people,
Thanks for the great component. 
It has reach functionally but due to lack of styling, I have implemented material theme for it. 

Unfortunately, some renderer **fixes are required** to get theme working. 

For example, I cannot set the style 100% row selection with a current approach. 
So with this pull request padding was changed and few titles are wrapped. 
It's not a big change but still, the dom is a little bit different.

I have checked that the normal tree style looks the same.

I don't want to have a copy of the component and it will be great if you will allow merge fixes on some point.

(This pull request contains only fixes)

The goal is to have the same code and only to switch theme:
import 'rc-tree/assets/index.less';
->
import 'rc-tree/assets/material-light.less';

Now it's working.
I have two branches:
fixes-for-material - only fixes for the tree and node.
material-theme - theme.

![loading example](https://user-images.githubusercontent.com/17121033/61591036-47041b00-abc1-11e9-8b96-51b7c89bde82.gif)
![chrome-capture](https://user-images.githubusercontent.com/17121033/61591037-479cb180-abc1-11e9-8cb8-fa0e00e67b66.gif)
![dark_mouse_over](https://user-images.githubusercontent.com/17121033/61591038-479cb180-abc1-11e9-8633-907da16b7153.gif)

Please check whether you are able to have as a feature in your repo.
Thanks in advance.
