### PR TITLE
Make `active` TreeNode prop optional

### DIFF
--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -37,7 +37,7 @@ export interface TreeNodeProps {
   data?: DataNode;
   isStart?: boolean[];
   isEnd?: boolean[];
-  active: boolean;
+  active?: boolean;
   onMouseMove?: React.MouseEventHandler<HTMLDivElement>;
 
   // By user


### PR DESCRIPTION
When I try to use the TypeScript types, it wants me to provide an `active` prop for `TreeNode`. Based on the documentation and the fact that the prop is under the "By parent" section, the user should not have to supply the `active` prop.