### PR TITLE
fix(typings): correct the definition of ScrollTo

### DIFF
--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { TreeNodeProps } from './TreeNode';
 
+export { ScrollTo } from 'rc-virtual-list/lib/List';
+
 export interface DataNode {
   checkable?: boolean;
   children?: DataNode[];
@@ -71,8 +73,6 @@ export interface FlattenNode {
   isStart: boolean[];
   isEnd: boolean[];
 }
-
-export type ScrollTo = (scroll: { key: Key }) => void;
 
 export type GetKey<RecordType> = (record: RecordType, index?: number) => Key;
 


### PR DESCRIPTION
`ScrollTo` 定义改从 `rc-virtual-list` 中获取