### PR TITLE
fix: only allow cross level horziontal drop when physical drop node is the last child itself

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -160,7 +160,7 @@ export interface TreeProps {
   virtual?: boolean;
 
   // direction for drag logic
-  direction?: Direction
+  direction?: Direction;
 }
 
 interface TreeState {
@@ -324,7 +324,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
-      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => cloneKeyEntities[key].key);
+      newState.expandedKeys = Object.keys(cloneKeyEntities).map((key) => cloneKeyEntities[key].key);
     } else if (!prevProps && props.defaultExpandedKeys) {
       newState.expandedKeys =
         props.autoExpandParent || props.defaultExpandParent
@@ -427,13 +427,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
    * But let's just keep it to avoid event trigger logic change.
    */
   onNodeDragEnter = (event: React.MouseEvent<HTMLDivElement>, node: NodeInstance) => {
-    const {
-      expandedKeys,
-      keyEntities,
-      dragChildrenKeys,
-      flattenNodes,
-      indent,
-    } = this.state;
+    const { expandedKeys, keyEntities, dragChildrenKeys, flattenNodes, indent } = this.state;
     const { onDragEnter, onExpand, allowDrop, direction } = this.props;
     const { pos } = node.props;
     const { dragNode } = this;
@@ -448,6 +442,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
       dragOverNodeKey,
     } = calcDropPosition(
       event,
+      dragNode,
       node,
       indent,
       this.dragStartMousePosition,
@@ -481,7 +476,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     if (!this.delayedDragEnterLogic) {
       this.delayedDragEnterLogic = {};
     }
-    Object.keys(this.delayedDragEnterLogic).forEach(key => {
+    Object.keys(this.delayedDragEnterLogic).forEach((key) => {
       clearTimeout(this.delayedDragEnterLogic[key]);
     });
 
@@ -550,13 +545,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
   };
 
   onNodeDragOver = (event: React.MouseEvent<HTMLDivElement>, node: NodeInstance) => {
-    const {
-      dragChildrenKeys,
-      flattenNodes,
-      keyEntities,
-      expandedKeys,
-      indent,
-    } = this.state;
+    const { dragChildrenKeys, flattenNodes, keyEntities, expandedKeys, indent } = this.state;
     const { onDragOver, allowDrop, direction } = this.props;
     const { dragNode } = this;
 
@@ -570,6 +559,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
       dragOverNodeKey,
     } = calcDropPosition(
       event,
+      dragNode,
       node,
       indent,
       this.dragStartMousePosition,
@@ -580,11 +570,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
       direction,
     );
 
-    if (
-      !dragNode ||
-      dragChildrenKeys.indexOf(dropTargetKey) !== -1 ||
-      !dropAllowed
-    ) {
+    if (!dragNode || dragChildrenKeys.indexOf(dropTargetKey) !== -1 || !dropAllowed) {
       // don't allow drop inside its children
       // don't allow drop when drop is not allowed caculated by calcDropPosition
       return;
@@ -651,7 +637,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
 
   // since stopPropagation() is called in treeNode
   // if onWindowDrag is called, whice means state is keeped, drag state should be cleared
-  onWindowDragEnd = event => {
+  onWindowDragEnd = (event) => {
     this.onNodeDragEnd(event, null, true);
     window.removeEventListener('dragend', this.onWindowDragEnd);
   };
@@ -693,13 +679,10 @@ class Tree extends React.Component<TreeProps, TreeState> {
     if (dropTargetKey === null) return;
 
     const abstractDropNodeProps = {
-      ...getTreeNodeProps(
-        dropTargetKey,
-        this.getTreeNodeRequiredProps(),
-      ),
+      ...getTreeNodeProps(dropTargetKey, this.getTreeNodeRequiredProps()),
       active: this.getActiveItem()?.data.key === dropTargetKey,
       data: this.state.keyEntities[dropTargetKey].node,
-    }
+    };
     const dropToChild = dragChildrenKeys.indexOf(dropTargetKey) !== -1;
 
     warning(
@@ -773,13 +756,13 @@ class Tree extends React.Component<TreeProps, TreeState> {
 
     // [Legacy] Not found related usage in doc or upper libs
     const selectedNodes = selectedKeys
-      .map(selectedKey => {
+      .map((selectedKey) => {
         const entity = keyEntities[selectedKey];
         if (!entity) return null;
 
         return entity.node;
       })
-      .filter(node => node);
+      .filter((node) => node);
 
     this.setUncontrolledState({ selectedKeys });
 
@@ -822,9 +805,9 @@ class Tree extends React.Component<TreeProps, TreeState> {
       checkedObj = { checked: checkedKeys, halfChecked: halfCheckedKeys };
 
       eventObj.checkedNodes = checkedKeys
-        .map(checkedKey => keyEntities[checkedKey])
-        .filter(entity => entity)
-        .map(entity => entity.node);
+        .map((checkedKey) => keyEntities[checkedKey])
+        .filter((entity) => entity)
+        .map((entity) => entity.node);
 
       this.setUncontrolledState({ checkedKeys });
     } else {
@@ -853,7 +836,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
       eventObj.checkedNodesPositions = [];
       eventObj.halfCheckedKeys = halfCheckedKeys;
 
-      checkedKeys.forEach(checkedKey => {
+      checkedKeys.forEach((checkedKey) => {
         const entity = keyEntities[checkedKey];
         if (!entity) return;
 
@@ -880,7 +863,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
   };
 
   onNodeLoad = (treeNode: EventDataNode) =>
-    new Promise<void>(resolve => {
+    new Promise<void>((resolve) => {
       // We need to get the latest state of loading/loaded keys
       this.setState(({ loadedKeys = [], loadingKeys = [] }): any => {
         const { loadData, onLoad } = this.props;
@@ -1116,7 +1099,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     }
   };
 
-  onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = event => {
+  onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = (event) => {
     const { activeKey, expandedKeys, checkedKeys } = this.state;
     const { onKeyDown, checkable, selectable } = this.props;
 
@@ -1218,7 +1201,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     let allPassed = true;
     const newState = {};
 
-    Object.keys(state).forEach(name => {
+    Object.keys(state).forEach((name) => {
       if (name in this.props) {
         allPassed = false;
         return;
@@ -1236,7 +1219,7 @@ class Tree extends React.Component<TreeProps, TreeState> {
     }
   };
 
-  scrollTo: ScrollTo = scroll => {
+  scrollTo: ScrollTo = (scroll) => {
     this.listRef.current.scrollTo(scroll);
   };
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -121,20 +121,23 @@ export function calcDropPosition(
     abstractDropNodeEntity = keyEntities[prevNodeKey];
   }
 
+  const initialAbstractDropNodeKey = abstractDropNodeEntity.key;
+
   const abstractDragOverEntity = abstractDropNodeEntity;
   const dragOverNodeKey = abstractDropNodeEntity.key;
 
   let dropPosition: -1 | 0 | 1 = 0;
   let dropLevelOffset = 0;
-  for (let i = 0; i < rawDropLevelOffset; i += 1) {
-    if (
-      isLastChild(abstractDropNodeEntity) &&
-      targetNode.props.eventKey === dragNode.props.eventKey
-    ) {
-      abstractDropNodeEntity = abstractDropNodeEntity.parent;
-      dropLevelOffset += 1;
-    } else {
-      break;
+
+  // Only allow to cross level drop when dragging on the last child itself
+  if (initialAbstractDropNodeKey === dragNode.props.eventKey) {
+    for (let i = 0; i < rawDropLevelOffset; i += 1) {
+      if (isLastChild(abstractDropNodeEntity)) {
+        abstractDropNodeEntity = abstractDropNodeEntity.parent;
+        dropLevelOffset += 1;
+      } else {
+        break;
+      }
     }
   }
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -6,7 +6,15 @@
 import React from 'react';
 import warning from 'rc-util/lib/warning';
 import TreeNode, { TreeNodeProps } from './TreeNode';
-import { NodeElement, Key, DataNode, DataEntity, NodeInstance, FlattenNode, Direction } from './interface';
+import {
+  NodeElement,
+  Key,
+  DataNode,
+  DataEntity,
+  NodeInstance,
+  FlattenNode,
+  Direction,
+} from './interface';
 import { TreeProps, AllowDrop } from './Tree';
 
 export function arrDel(list: Key[], value: Key) {
@@ -56,7 +64,7 @@ export function getDragChildrenKeys(dragNodeKey: Key, keyEntities: Record<Key, D
   return dragChildrenKeys;
 }
 
-export function isLastChild (treeNodeEntity: DataEntity) {
+export function isLastChild(treeNodeEntity: DataEntity) {
   if (treeNodeEntity.parent) {
     const posArr = posToArr(treeNodeEntity.pos);
     return Number(posArr[posArr.length - 1]) === treeNodeEntity.parent.children.length - 1;
@@ -64,7 +72,7 @@ export function isLastChild (treeNodeEntity: DataEntity) {
   return false;
 }
 
-export function isFirstChild (treeNodeEntity: DataEntity) {
+export function isFirstChild(treeNodeEntity: DataEntity) {
   const posArr = posToArr(treeNodeEntity.pos);
   return Number(posArr[posArr.length - 1]) === 0;
 }
@@ -72,11 +80,12 @@ export function isFirstChild (treeNodeEntity: DataEntity) {
 // Only used when drag, not affect SSR.
 export function calcDropPosition(
   event: React.MouseEvent,
+  dragNode: NodeInstance,
   targetNode: NodeInstance,
   indent: number,
   startMousePosition: {
-    x: number,
-    y: number,
+    x: number;
+    y: number;
   },
   allowDrop: AllowDrop,
   flattenedNodes: FlattenNode[],
@@ -84,18 +93,19 @@ export function calcDropPosition(
   expandKeys: Key[],
   direction: Direction,
 ): {
-  dropPosition: -1 | 0 | 1,
-  dropLevelOffset: number,
-  dropTargetKey: Key,
-  dropTargetPos: string,
-  dropContainerKey: Key,
-  dragOverNodeKey: Key,
-  dropAllowed: boolean,
+  dropPosition: -1 | 0 | 1;
+  dropLevelOffset: number;
+  dropTargetKey: Key;
+  dropTargetPos: string;
+  dropContainerKey: Key;
+  dragOverNodeKey: Key;
+  dropAllowed: boolean;
 } {
   const { clientX, clientY } = event;
   const { top, height } = (event.target as HTMLElement).getBoundingClientRect();
   // optional chain for testing
-  const horizontalMouseOffset = (direction === 'rtl' ? -1 : 1) * ((startMousePosition?.x || 0) - clientX);
+  const horizontalMouseOffset =
+    (direction === 'rtl' ? -1 : 1) * ((startMousePosition?.x || 0) - clientX);
   const rawDropLevelOffset = (horizontalMouseOffset - 12) / indent;
 
   // find abstract drop node by horizontal offset
@@ -104,7 +114,7 @@ export function calcDropPosition(
   if (clientY < top + height / 2) {
     // first half, set abstract drop node to previous node
     const nodeIndex = flattenedNodes.findIndex(
-      flattenedNode => flattenedNode.data.key === abstractDropNodeEntity.key,
+      (flattenedNode) => flattenedNode.data.key === abstractDropNodeEntity.key,
     );
     const prevNodeIndex = nodeIndex <= 0 ? 0 : nodeIndex - 1;
     const prevNodeKey = flattenedNodes[prevNodeIndex].data.key;
@@ -118,7 +128,8 @@ export function calcDropPosition(
   let dropLevelOffset = 0;
   for (let i = 0; i < rawDropLevelOffset; i += 1) {
     if (
-      isLastChild(abstractDropNodeEntity)
+      isLastChild(abstractDropNodeEntity) &&
+      targetNode.props.eventKey === dragNode.props.eventKey
     ) {
       abstractDropNodeEntity = abstractDropNodeEntity.parent;
       dropLevelOffset += 1;
@@ -127,7 +138,7 @@ export function calcDropPosition(
     }
   }
 
-  const abstractDropDataNode = abstractDropNodeEntity.node
+  const abstractDropDataNode = abstractDropNodeEntity.node;
   let dropAllowed = true;
   if (
     isFirstChild(abstractDropNodeEntity) &&
@@ -140,33 +151,35 @@ export function calcDropPosition(
     abstractDropNodeEntity.key === targetNode.props.eventKey
   ) {
     // first half of first node in first level
-    dropPosition = -1
+    dropPosition = -1;
   } else if (
     (abstractDragOverEntity.children || []).length &&
     expandKeys.includes(dragOverNodeKey)
   ) {
     // drop on expanded node
     // only allow drop inside
-    if (allowDrop({
-      dropNode: abstractDropDataNode,
-      dropPosition: 0,
-    })) {
+    if (
+      allowDrop({
+        dropNode: abstractDropDataNode,
+        dropPosition: 0,
+      })
+    ) {
       dropPosition = 0;
     } else {
-      dropAllowed = false
+      dropAllowed = false;
     }
-  } else if (
-    dropLevelOffset === 0
-  ) {
+  } else if (dropLevelOffset === 0) {
     if (rawDropLevelOffset > -1.5) {
       // | Node     | <- abstractDropNode
       // | -^-===== | <- mousePosition
       // 1. try drop after
       // 2. do not allow drop
-      if (allowDrop({
-        dropNode: abstractDropDataNode,
-        dropPosition: 1,
-      })) {
+      if (
+        allowDrop({
+          dropNode: abstractDropDataNode,
+          dropPosition: 1,
+        })
+      ) {
         dropPosition = 1;
       } else {
         dropAllowed = false;
@@ -179,15 +192,19 @@ export function calcDropPosition(
       // 1. try drop inside
       // 2. try drop after
       // 3. do not allow drop
-      if (allowDrop({
-        dropNode: abstractDropDataNode,
-        dropPosition: 0,
-      })) {
+      if (
+        allowDrop({
+          dropNode: abstractDropDataNode,
+          dropPosition: 0,
+        })
+      ) {
         dropPosition = 0;
-      } else if (allowDrop({
-        dropNode: abstractDropDataNode,
-        dropPosition: 1,
-      })) {
+      } else if (
+        allowDrop({
+          dropNode: abstractDropDataNode,
+          dropPosition: 1,
+        })
+      ) {
         dropPosition = 1;
       } else {
         dropAllowed = false;
@@ -199,10 +216,12 @@ export function calcDropPosition(
     // --^--|----=====| <- mousePosition
     // 1. try insert after Node1
     // 2. do not allow drop
-    if (allowDrop({
-      dropNode: abstractDropDataNode,
-      dropPosition: 1,
-    })) {
+    if (
+      allowDrop({
+        dropNode: abstractDropDataNode,
+        dropPosition: 1,
+      })
+    ) {
       dropPosition = 1;
     } else {
       dropAllowed = false;
@@ -215,7 +234,7 @@ export function calcDropPosition(
     dropTargetKey: abstractDropNodeEntity.key,
     dropTargetPos: abstractDropNodeEntity.pos,
     dragOverNodeKey,
-    dropContainerKey: dropPosition === 0 ? null : (abstractDropNodeEntity.parent?.key || null),
+    dropContainerKey: dropPosition === 0 ? null : abstractDropNodeEntity.parent?.key || null,
     dropAllowed,
   };
 }
@@ -312,7 +331,7 @@ export function conductExpandParent(keyList: Key[], keyEntities: Record<Key, Dat
     }
   }
 
-  (keyList || []).forEach(key => {
+  (keyList || []).forEach((key) => {
     conductUp(key);
   });
 
@@ -324,7 +343,7 @@ export function conductExpandParent(keyList: Key[], keyEntities: Record<Key, Dat
  */
 export function getDataAndAria(props: Partial<TreeProps | TreeNodeProps>) {
   const omitProps: Record<string, string> = {};
-  Object.keys(props).forEach(key => {
+  Object.keys(props).forEach((key) => {
     if (key.startsWith('data-') || key.startsWith('aria-')) {
       omitProps[key] = props[key];
     }

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -129,7 +129,7 @@ export function calcDropPosition(
   let dropPosition: -1 | 0 | 1 = 0;
   let dropLevelOffset = 0;
 
-  // Only allow to cross level drop when dragging on the last child itself
+  // Only allow cross level drop when dragging on the last child itself
   if (initialAbstractDropNodeKey === dragNode.props.eventKey) {
     for (let i = 0; i < rawDropLevelOffset; i += 1) {
       if (isLastChild(abstractDropNodeEntity)) {

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -15,8 +15,8 @@ const OPEN_CLASSNAME = '.rc-tree-switcher_open';
 const CHECKED_CLASSNAME = '.rc-tree-checkbox-checked';
 const SELECTED_CLASSNAME = '.rc-tree-node-selected';
 
-const delay = timeout =>
-  new Promise(resolve => {
+const delay = (timeout) =>
+  new Promise((resolve) => {
     setTimeout(resolve, timeout);
   });
 
@@ -181,12 +181,7 @@ describe('Tree Basic', () => {
       );
       const switcher = wrapper.find('.rc-tree-switcher');
 
-      let node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
+      let node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
       switcher.simulate('click');
       expect(handleExpand).toHaveBeenCalledWith(['0-0'], {
         expanded: true,
@@ -194,12 +189,7 @@ describe('Tree Basic', () => {
         nativeEvent: expect.anything(),
       });
 
-      node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
+      node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
       switcher.simulate('click');
       expect(handleExpand).toHaveBeenCalledWith([], {
         expanded: false,
@@ -232,7 +222,7 @@ describe('Tree Basic', () => {
         </Tree>,
       );
       wrapper.find('.rc-tree-switcher').simulate('click');
-      wrapper.find('.rc-tree-checkbox').forEach(checkbox => {
+      wrapper.find('.rc-tree-checkbox').forEach((checkbox) => {
         expect(checkbox.is(CHECKED_CLASSNAME)).toBe(true);
       });
     });
@@ -276,20 +266,9 @@ describe('Tree Basic', () => {
         </Tree>,
       );
       wrapper.find('.rc-tree-switcher').simulate('click');
-      wrapper
-        .find('.rc-tree-checkbox')
-        .at(1)
-        .simulate('click');
-      wrapper
-        .find('.rc-tree-checkbox')
-        .at(2)
-        .simulate('click');
-      expect(
-        wrapper
-          .find('.rc-tree-checkbox')
-          .first()
-          .is(CHECKED_CLASSNAME),
-      ).toBe(true);
+      wrapper.find('.rc-tree-checkbox').at(1).simulate('click');
+      wrapper.find('.rc-tree-checkbox').at(2).simulate('click');
+      expect(wrapper.find('.rc-tree-checkbox').first().is(CHECKED_CLASSNAME)).toBe(true);
     });
 
     it('turns parent node to half checked when child is checked', () => {
@@ -302,16 +281,10 @@ describe('Tree Basic', () => {
         </Tree>,
       );
       wrapper.find('.rc-tree-switcher').simulate('click');
-      wrapper
-        .find('.rc-tree-checkbox')
-        .last()
-        .simulate('click');
-      expect(
-        wrapper
-          .find('.rc-tree-checkbox')
-          .first()
-          .is('.rc-tree-checkbox-indeterminate'),
-      ).toBe(true);
+      wrapper.find('.rc-tree-checkbox').last().simulate('click');
+      expect(wrapper.find('.rc-tree-checkbox').first().is('.rc-tree-checkbox-indeterminate')).toBe(
+        true,
+      );
     });
 
     it('turns parent node to checked if it is half checked', () => {
@@ -324,15 +297,9 @@ describe('Tree Basic', () => {
         </Tree>,
       );
       wrapper.find('.rc-tree-switcher').simulate('click');
-      wrapper
-        .find('.rc-tree-checkbox')
-        .last()
-        .simulate('click');
-      wrapper
-        .find('.rc-tree-checkbox')
-        .first()
-        .simulate('click');
-      wrapper.find('.rc-tree-checkbox').forEach(checkbox => {
+      wrapper.find('.rc-tree-checkbox').last().simulate('click');
+      wrapper.find('.rc-tree-checkbox').first().simulate('click');
+      wrapper.find('.rc-tree-checkbox').forEach((checkbox) => {
         expect(checkbox.is(CHECKED_CLASSNAME)).toBe(true);
       });
     });
@@ -351,16 +318,8 @@ describe('Tree Basic', () => {
       const nodeData00 = { title: 'parent 1', key: '0-0' };
       const nodeData000 = { title: 'leaf 1', key: '0-0-0' };
 
-      let node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
-      wrapper
-        .find('.rc-tree-checkbox')
-        .first()
-        .simulate('click');
+      let node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
+      wrapper.find('.rc-tree-checkbox').first().simulate('click');
       expect(handleCheck).toHaveBeenCalledWith(
         ['0-0', '0-0-0'],
         objectMatcher({
@@ -377,16 +336,8 @@ describe('Tree Basic', () => {
         }),
       );
 
-      node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .last()
-          .props(),
-      );
-      wrapper
-        .find('.rc-tree-checkbox')
-        .last()
-        .simulate('click');
+      node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).last().props());
+      wrapper.find('.rc-tree-checkbox').last().simulate('click');
       expect(handleCheck).toHaveBeenCalledWith(
         [],
         objectMatcher({
@@ -411,10 +362,7 @@ describe('Tree Basic', () => {
           </TreeNode>
         </Tree>,
       );
-      wrapper
-        .find('.rc-tree-checkbox')
-        .at(1)
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').at(1).simulate('click');
       wrapper.setProps({
         children: (
           <TreeNode title="parent 1" key="0-0">
@@ -424,12 +372,7 @@ describe('Tree Basic', () => {
           </TreeNode>
         ),
       });
-      expect(() =>
-        wrapper
-          .find('.rc-tree-checkbox')
-          .at(2)
-          .simulate('click'),
-      ).not.toThrow();
+      expect(() => wrapper.find('.rc-tree-checkbox').at(2).simulate('click')).not.toThrow();
     });
     // https://github.com/react-component/tree/issues/90
     it('check works correctly after adding children dynamically', () => {
@@ -440,10 +383,7 @@ describe('Tree Basic', () => {
           </TreeNode>
         </Tree>,
       );
-      wrapper
-        .find('.rc-tree-checkbox')
-        .at(1)
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').at(1).simulate('click');
       wrapper.setProps({
         children: (
           <TreeNode title="parent 1" key="0-0">
@@ -452,18 +392,13 @@ describe('Tree Basic', () => {
           </TreeNode>
         ),
       });
-      expect(() =>
-        wrapper
-          .find('.rc-tree-checkbox')
-          .at(2)
-          .simulate('click'),
-      ).not.toThrow();
+      expect(() => wrapper.find('.rc-tree-checkbox').at(2).simulate('click')).not.toThrow();
     });
 
     // https://github.com/ant-design/ant-design/issues/7353
     it('check children after changing from children[disableCheckbox] from true to false', () => {
       let checkedKeys = null;
-      const mockHandleCheck = keys => (checkedKeys = keys);
+      const mockHandleCheck = (keys) => (checkedKeys = keys);
       function Test({ disableCheckbox }) {
         return (
           <Tree checkable onCheck={mockHandleCheck}>
@@ -476,17 +411,10 @@ describe('Tree Basic', () => {
         );
       }
       const wrapper = mount(<Test disableCheckbox />);
-      wrapper
-        .find('.rc-tree-checkbox')
-        .first()
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').first().simulate('click');
       expect(checkedKeys).toEqual(['0-0']);
       wrapper.setProps({ disableCheckbox: false });
-      wrapper
-        .find('.rc-tree-checkbox')
-        .first()
-        .simulate('click')
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').first().simulate('click').simulate('click');
       expect(checkedKeys).toEqual(['0-0', '0-0-1', '0-0-2', '0-0-3']);
     });
 
@@ -526,10 +454,7 @@ describe('Tree Basic', () => {
         }
       }
       const wrapper = mount(<Test />);
-      wrapper
-        .find('.rc-tree-checkbox')
-        .first()
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').first().simulate('click');
 
       expect(renderToJson(wrapper.render())).toMatchSnapshot();
     });
@@ -566,10 +491,7 @@ describe('Tree Basic', () => {
         </Tree>,
       );
 
-      wrapper
-        .find('.rc-tree-checkbox')
-        .last()
-        .simulate('click');
+      wrapper.find('.rc-tree-checkbox').last().simulate('click');
 
       expect(onCheck.mock.calls[0][0].sort()).toEqual(['0-0', '0-0-1']);
     });
@@ -584,22 +506,9 @@ describe('Tree Basic', () => {
           </Tree>,
         );
         wrapper.find('.rc-tree-switcher').simulate('click');
-        wrapper
-          .find('.rc-tree-checkbox')
-          .first()
-          .simulate('click');
-        expect(
-          wrapper
-            .find('.rc-tree-checkbox')
-            .first()
-            .is(CHECKED_CLASSNAME),
-        ).toBe(true);
-        expect(
-          wrapper
-            .find('.rc-tree-checkbox')
-            .last()
-            .is(CHECKED_CLASSNAME),
-        ).toBe(false);
+        wrapper.find('.rc-tree-checkbox').first().simulate('click');
+        expect(wrapper.find('.rc-tree-checkbox').first().is(CHECKED_CLASSNAME)).toBe(true);
+        expect(wrapper.find('.rc-tree-checkbox').last().is(CHECKED_CLASSNAME)).toBe(false);
       });
 
       describe('controlled mode', () => {
@@ -611,7 +520,7 @@ describe('Tree Basic', () => {
             },
           };
 
-          handleCheck = checkedKeys => {
+          handleCheck = (checkedKeys) => {
             this.setState({ checkedKeys });
           };
 
@@ -634,22 +543,9 @@ describe('Tree Basic', () => {
         it('do not check children', () => {
           const wrapper = mount(<App />);
           wrapper.find('.rc-tree-switcher').simulate('click');
-          wrapper
-            .find('.rc-tree-checkbox')
-            .first()
-            .simulate('click');
-          expect(
-            wrapper
-              .find('.rc-tree-checkbox')
-              .first()
-              .is(CHECKED_CLASSNAME),
-          ).toBe(true);
-          expect(
-            wrapper
-              .find('.rc-tree-checkbox')
-              .last()
-              .is(CHECKED_CLASSNAME),
-          ).toBe(false);
+          wrapper.find('.rc-tree-checkbox').first().simulate('click');
+          expect(wrapper.find('.rc-tree-checkbox').first().is(CHECKED_CLASSNAME)).toBe(true);
+          expect(wrapper.find('.rc-tree-checkbox').last().is(CHECKED_CLASSNAME)).toBe(false);
         });
 
         it('do not uncheck parent', () => {
@@ -658,22 +554,9 @@ describe('Tree Basic', () => {
             checkedKeys: { checked: ['0-0', '0-0-0'], halfChecked: [] },
           });
           wrapper.find('.rc-tree-switcher').simulate('click');
-          wrapper
-            .find('.rc-tree-checkbox')
-            .last()
-            .simulate('click');
-          expect(
-            wrapper
-              .find('.rc-tree-checkbox')
-              .first()
-              .is(CHECKED_CLASSNAME),
-          ).toBe(true);
-          expect(
-            wrapper
-              .find('.rc-tree-checkbox')
-              .last()
-              .is(CHECKED_CLASSNAME),
-          ).toBe(false);
+          wrapper.find('.rc-tree-checkbox').last().simulate('click');
+          expect(wrapper.find('.rc-tree-checkbox').first().is(CHECKED_CLASSNAME)).toBe(true);
+          expect(wrapper.find('.rc-tree-checkbox').last().is(CHECKED_CLASSNAME)).toBe(false);
         });
       });
     });
@@ -698,12 +581,7 @@ describe('Tree Basic', () => {
 
       expect(firstNode().hasClass('rc-tree-checkbox-checked')).toBe(true);
       expect(firstNode().hasClass('rc-tree-checkbox-indeterminate')).toBe(false);
-      expect(
-        wrapper
-          .state()
-          .checkedKeys.slice()
-          .sort(),
-      ).toEqual(['0-0-1', '0-0-2', '0-0'].sort());
+      expect(wrapper.state().checkedKeys.slice().sort()).toEqual(['0-0-1', '0-0-2', '0-0'].sort());
 
       firstNode().simulate('click');
       expect(firstNode().hasClass('rc-tree-checkbox-checked')).toBe(false);
@@ -725,22 +603,12 @@ describe('Tree Basic', () => {
         </Tree>,
       );
 
-      const firstNode = () =>
-        wrapper
-          .find(TreeNode)
-          .first()
-          .find('.rc-tree-checkbox')
-          .first();
+      const firstNode = () => wrapper.find(TreeNode).first().find('.rc-tree-checkbox').first();
 
       firstNode().simulate('click');
       expect(firstNode().hasClass('rc-tree-checkbox-checked')).toBe(true);
       expect(firstNode().hasClass('rc-tree-checkbox-indeterminate')).toBe(false);
-      expect(
-        wrapper
-          .state()
-          .checkedKeys.slice()
-          .sort(),
-      ).toEqual(['0-0-1', '0-0-2', '0-0'].sort());
+      expect(wrapper.state().checkedKeys.slice().sort()).toEqual(['0-0-1', '0-0-2', '0-0'].sort());
 
       firstNode().simulate('click');
       expect(firstNode().hasClass('rc-tree-checkbox-checked')).toBe(false);
@@ -762,18 +630,8 @@ describe('Tree Basic', () => {
           </TreeNode>
         </Tree>,
       );
-      const getParent = () =>
-        wrapper
-          .find(TreeNode)
-          .at(1)
-          .find('.rc-tree-checkbox')
-          .first();
-      const getNode = () =>
-        wrapper
-          .find(TreeNode)
-          .at(2)
-          .find('.rc-tree-checkbox')
-          .first();
+      const getParent = () => wrapper.find(TreeNode).at(1).find('.rc-tree-checkbox').first();
+      const getNode = () => wrapper.find(TreeNode).at(2).find('.rc-tree-checkbox').first();
 
       getNode().simulate('click');
       expect(getNode().hasClass('rc-tree-checkbox-checked')).toBe(true);
@@ -822,12 +680,7 @@ describe('Tree Basic', () => {
       );
       const nodeContent = wrapper.find('.rc-tree-node-content-wrapper');
 
-      let node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
+      let node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
       nodeContent.simulate('click');
       expect(handleSelect).toHaveBeenCalledWith(
         ['0-0'],
@@ -840,12 +693,7 @@ describe('Tree Basic', () => {
         }),
       );
 
-      node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
+      node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
       nodeContent.simulate('click');
       expect(handleSelect).toHaveBeenCalledWith(
         [],
@@ -875,16 +723,8 @@ describe('Tree Basic', () => {
       const dataNode1 = { title: 'parent 1', key: '0-0' };
       const dataNode2 = { title: 'leaf 1', key: '0-0-0' };
 
-      let node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .first()
-          .props(),
-      );
-      wrapper
-        .find('.rc-tree-node-content-wrapper')
-        .first()
-        .simulate('click');
+      let node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).first().props());
+      wrapper.find('.rc-tree-node-content-wrapper').first().simulate('click');
       expect(handleCheck).toHaveBeenCalledWith(
         ['0-0', '0-0-0'],
         objectMatcher({
@@ -901,16 +741,8 @@ describe('Tree Basic', () => {
         }),
       );
 
-      node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .last()
-          .props(),
-      );
-      wrapper
-        .find('.rc-tree-node-content-wrapper')
-        .last()
-        .simulate('click');
+      node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).last().props());
+      wrapper.find('.rc-tree-node-content-wrapper').last().simulate('click');
       expect(handleCheck).toHaveBeenCalledWith(
         [],
         objectMatcher({
@@ -997,12 +829,7 @@ describe('Tree Basic', () => {
       </Tree>,
     );
 
-    expect(
-      wrapper
-        .find(InternalTreeNode)
-        .find('div')
-        .is('.filter-node'),
-    ).toBe(true);
+    expect(wrapper.find(InternalTreeNode).find('div').is('.filter-node')).toBe(true);
   });
 
   it('loads nodes asynchronously', () => {
@@ -1035,12 +862,7 @@ describe('Tree Basic', () => {
       const onDragStart = jest.fn();
       const wrapper = mount(createTree({ onDragStart }));
       const treeNode = wrapper.find('.dragTarget > .rc-tree-node-content-wrapper');
-      const node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(1)
-          .props(),
-      );
+      const node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(1).props());
       treeNode.simulate('dragStart');
       const event = onDragStart.mock.calls[0][0];
       expect(event.node).toEqual(node);
@@ -1057,20 +879,12 @@ describe('Tree Basic', () => {
       await delay(900);
       expect(onDragEnter).not.toHaveBeenCalled();
 
-      wrapper
-        .find('.dropTarget')
-        .at(0)
-        .simulate('dragEnter');
+      wrapper.find('.dropTarget').at(0).simulate('dragEnter');
       expect(onDragEnter).toHaveBeenCalled();
 
       await delay(900);
       wrapper.update();
-      const node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(2)
-          .props(),
-      );
+      const node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(2).props());
       const event = onDragEnter.mock.calls[0][0];
       expect(event.node.key).toEqual(node.key);
       expect(event.expandedKeys).toEqual(['0-0', '0-0-0-1']);
@@ -1080,17 +894,9 @@ describe('Tree Basic', () => {
     it('fires dragOver event', () => {
       const onDragOver = jest.fn();
       const wrapper = mount(createTree({ onDragOver }));
-      const node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(2)
-          .props(),
-      );
+      const node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(2).props());
       wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart');
-      wrapper
-        .find('.dropTarget')
-        .at(0)
-        .simulate('dragOver');
+      wrapper.find('.dropTarget').at(0).simulate('dragOver');
       const event = onDragOver.mock.calls[0][0];
       expect(event.node).toEqual(node);
     });
@@ -1098,16 +904,8 @@ describe('Tree Basic', () => {
     it('fires dragLeave event', () => {
       const onDragLeave = jest.fn();
       const wrapper = mount(createTree({ onDragLeave }));
-      const node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(2)
-          .props(),
-      );
-      wrapper
-        .find('.dropTarget')
-        .at(0)
-        .simulate('dragLeave');
+      const node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(2).props());
+      wrapper.find('.dropTarget').at(0).simulate('dragLeave');
       const event = onDragLeave.mock.calls[0][0];
       expect(event.node).toEqual(node);
     });
@@ -1118,22 +916,9 @@ describe('Tree Basic', () => {
       wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart');
       wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragEnter');
       wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragOver');
-      const dropNode = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(2)
-          .props(),
-      );
-      const dragNode = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(1)
-          .props(),
-      );
-      wrapper
-        .find('.dropTarget')
-        .at(0)
-        .simulate('drop');
+      const dropNode = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(2).props());
+      const dragNode = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(1).props());
+      wrapper.find('.dropTarget').at(0).simulate('drop');
       const event = onDrop.mock.calls[0][0];
       expect(event.node).toEqual(dropNode);
       expect(event.dragNode).toEqual(dragNode);
@@ -1143,12 +928,7 @@ describe('Tree Basic', () => {
     it('fires dropEnd event', () => {
       const onDragEnd = jest.fn();
       const wrapper = mount(createTree({ onDragEnd }));
-      const node = convertNodePropsToEventData(
-        wrapper
-          .find(InternalTreeNode)
-          .at(1)
-          .props(),
-      );
+      const node = convertNodePropsToEventData(wrapper.find(InternalTreeNode).at(1).props());
       wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragEnd');
       const event = onDragEnd.mock.calls[0][0];
       expect(event.node).toEqual(node);
@@ -1166,23 +946,14 @@ describe('Tree Basic', () => {
       const normalTree = wrapper.find(Tree).at(1);
 
       dragTree.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart');
-      normalTree
-        .find('.dropTarget')
-        .at(0)
-        .simulate('dragEnter');
-      normalTree
-        .find('.dropTarget')
-        .at(0)
-        .simulate('dragOver');
-      normalTree
-        .find('.dropTarget')
-        .at(0)
-        .simulate('drop');
+      normalTree.find('.dropTarget').at(0).simulate('dragEnter');
+      normalTree.find('.dropTarget').at(0).simulate('dragOver');
+      normalTree.find('.dropTarget').at(0).simulate('drop');
     });
 
     describe('full steps', () => {
       function dropTarget(targetSelector) {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           const wrapper = mount(
             <Tree draggable={() => true} defaultExpandAll onExpand={() => {}}>
               <TreeNode key="0-0" className="dragTarget">
@@ -1279,7 +1050,7 @@ describe('Tree Basic', () => {
       afterEach(() => {
         domSpy.mockRestore();
       });
-      ['ltr', 'rtl'].forEach(dir => {
+      ['ltr', 'rtl'].forEach((dir) => {
         const base = dir === 'ltr' ? 1 : -1;
         it('allowDrop all nodes', () => {
           const onDrop = jest.fn();
@@ -1311,8 +1082,9 @@ describe('Tree Basic', () => {
             clientY: 600,
           });
           wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('drop');
-          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1');
-          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(2);
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
+          // (in ltr) drag from right to left, should be insert after, so drop position is 1
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
           wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart', {
             clientX: base * 500,
             clientY: 500,
@@ -1642,8 +1414,9 @@ describe('Tree Basic', () => {
             clientY: 600,
           });
           wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('drop');
-          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1');
-          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(2);
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
+          // (in ltr) drag from right to left, should be insert after, so drop position is 1
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
           wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart', {
             clientX: base * 500,
             clientY: 500,
@@ -1698,9 +1471,9 @@ describe('Tree Basic', () => {
     expect(() => {
       mount(
         <Tree>
-          {[0, 1].map(i => (
+          {[0, 1].map((i) => (
             <TreeNode title={i} key={i}>
-              {[2, 3].map(j => (
+              {[2, 3].map((j) => (
                 <TreeNode title={j} key={`${i}_${j}`} />
               ))}
               <TreeNode title="4" key={`${i}_4`} />
@@ -1715,7 +1488,7 @@ describe('Tree Basic', () => {
     const wrapper = render(
       <Tree>
         <TreeNode title="0" key="0">
-          {[1, 2].map(i => (
+          {[1, 2].map((i) => (
             <TreeNode title={i} key={i} />
           ))}
           <TreeNode title="3" key="3" />
@@ -1773,7 +1546,7 @@ describe('Tree Basic', () => {
           checkable
           defaultExpandAll
           checkedKeys={checkedKeys}
-          onCheck={keys => {
+          onCheck={(keys) => {
             setCheckedKeys(keys);
             onCheck(keys);
           }}
@@ -1785,17 +1558,11 @@ describe('Tree Basic', () => {
     const wrapper = mount(<Demo />);
     wrapper.update();
 
-    wrapper
-      .find('.rc-tree-checkbox')
-      .first()
-      .simulate('click');
+    wrapper.find('.rc-tree-checkbox').first().simulate('click');
     expect(onCheck).toHaveBeenCalledWith([11, 22]);
 
     onCheck.mockReset();
-    wrapper
-      .find('.rc-tree-checkbox')
-      .last()
-      .simulate('click');
+    wrapper.find('.rc-tree-checkbox').last().simulate('click');
     expect(onCheck).toHaveBeenCalledWith([]);
   });
 
@@ -1855,10 +1622,7 @@ describe('Tree Basic', () => {
     wrapper.setProps({ expandedKeys: undefined });
 
     // Click should not crash
-    wrapper
-      .find('.rc-tree-switcher')
-      .first()
-      .simulate('click');
+    wrapper.find('.rc-tree-switcher').first().simulate('click');
   });
 
   it('controlled should block expanded', () => {
@@ -1869,10 +1633,7 @@ describe('Tree Basic', () => {
       />,
     );
 
-    wrapper
-      .find('.rc-tree-switcher')
-      .first()
-      .simulate('click');
+    wrapper.find('.rc-tree-switcher').first().simulate('click');
     expect(wrapper.find('List').props().data).toHaveLength(2);
   });
 
@@ -1903,23 +1664,13 @@ describe('Tree Basic', () => {
 
     // trigger click to expand node
     wrapper.find('.rc-tree-switcher').simulate('click');
-    expect(
-      wrapper
-        .find('.rc-tree-switcher')
-        .first()
-        .is(OPEN_CLASSNAME),
-    ).toBe(true);
+    expect(wrapper.find('.rc-tree-switcher').first().is(OPEN_CLASSNAME)).toBe(true);
     expect(onExpand).toBeCalled();
 
     // click again
     onExpand.mockReset();
     wrapper.find('.rc-tree-switcher').simulate('click');
-    expect(
-      wrapper
-        .find('.rc-tree-switcher')
-        .first()
-        .is(OPEN_CLASSNAME),
-    ).toBe(true);
+    expect(wrapper.find('.rc-tree-switcher').first().is(OPEN_CLASSNAME)).toBe(true);
     expect(onExpand).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/29470

coverage falls due to the line compression by prettier.