### PR TITLE
feat: add dragnode info into tree#allowdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ see examples
 | onSelect | click the treeNode to fire | function(selectedKeys, e:{selected: bool, selectedNodes, node, event, nativeEvent}) | - |
 | switcherIcon | specific the switcher icon. | ReactNode / (props: TreeNodeAttribute) => ReactNode | - |
 | virtual | Disable virtual scroll when `false` | boolean | - |
-| allowDrop | Whether to allow drop on node | ({ dropNode, dropPosition }) => boolean | - |
+| allowDrop | Whether to allow drop on node | ({ dragNode, dropNode, dropPosition }) => boolean | - |
 | dropIndicatorRender | The indicator to render when dragging | ({ dropPosition, dropLevelOffset, indent: number, prefixCls }) => ReactNode| - |
 | direction | Display direction of the tree, it may affect dragging behavior | `ltr` \| `rtl` | - |
 
@@ -138,4 +138,3 @@ rc-tree is released under the MIT license.
 - [jqTree](https://mbraak.github.io/jqTree/)
 - [jquery.treeselect](https://travistidwell.com/jquery.treeselect.js/)
 - [Angular Multi Select Tree](https://a5hik.github.io/angular-multi-select-tree/)
-

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -60,7 +60,12 @@ interface CheckInfo {
   halfCheckedKeys?: Key[];
 }
 
-export type AllowDrop = (options: { dropNode: DataNode; dropPosition: -1 | 0 | 1 }) => boolean;
+export interface AllowDropOptions {
+  dragNode: DataNode;
+  dropNode: DataNode;
+  dropPosition: -1 | 0 | 1;
+}
+export type AllowDrop = (options: AllowDropOptions) => boolean;
 
 export interface TreeProps {
   prefixCls: string;
@@ -675,13 +680,8 @@ class Tree extends React.Component<TreeProps, TreeState> {
   };
 
   onNodeDrop = (event: React.DragEvent<HTMLDivElement>, node, outsideTree: boolean = false) => {
-    const {
-      dragChildrenKeys,
-      dropPosition,
-      dropTargetKey,
-      dropTargetPos,
-      dropAllowed,
-    } = this.state;
+    const { dragChildrenKeys, dropPosition, dropTargetKey, dropTargetPos, dropAllowed } =
+      this.state;
 
     if (!dropAllowed) return;
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -141,7 +141,7 @@ export function calcDropPosition(
     }
   }
 
-  const abstractDragDataNode = keyEntities[dragNode.props.eventKey].node;
+  const abstractDragDataNode = dragNode.props.data;
   const abstractDropDataNode = abstractDropNodeEntity.node;
   let dropAllowed = true;
   if (

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -114,7 +114,7 @@ export function calcDropPosition(
   if (clientY < top + height / 2) {
     // first half, set abstract drop node to previous node
     const nodeIndex = flattenedNodes.findIndex(
-      (flattenedNode) => flattenedNode.data.key === abstractDropNodeEntity.key,
+      flattenedNode => flattenedNode.data.key === abstractDropNodeEntity.key,
     );
     const prevNodeIndex = nodeIndex <= 0 ? 0 : nodeIndex - 1;
     const prevNodeKey = flattenedNodes[prevNodeIndex].data.key;
@@ -141,6 +141,7 @@ export function calcDropPosition(
     }
   }
 
+  const abstractDragDataNode = keyEntities[dragNode.props.eventKey].node;
   const abstractDropDataNode = abstractDropNodeEntity.node;
   let dropAllowed = true;
   if (
@@ -148,6 +149,7 @@ export function calcDropPosition(
     abstractDropNodeEntity.level === 0 &&
     clientY < top + height / 2 &&
     allowDrop({
+      dragNode: abstractDragDataNode,
       dropNode: abstractDropDataNode,
       dropPosition: -1,
     }) &&
@@ -163,6 +165,7 @@ export function calcDropPosition(
     // only allow drop inside
     if (
       allowDrop({
+        dragNode: abstractDragDataNode,
         dropNode: abstractDropDataNode,
         dropPosition: 0,
       })
@@ -179,6 +182,7 @@ export function calcDropPosition(
       // 2. do not allow drop
       if (
         allowDrop({
+          dragNode: abstractDragDataNode,
           dropNode: abstractDropDataNode,
           dropPosition: 1,
         })
@@ -197,6 +201,7 @@ export function calcDropPosition(
       // 3. do not allow drop
       if (
         allowDrop({
+          dragNode: abstractDragDataNode,
           dropNode: abstractDropDataNode,
           dropPosition: 0,
         })
@@ -204,6 +209,7 @@ export function calcDropPosition(
         dropPosition = 0;
       } else if (
         allowDrop({
+          dragNode: abstractDragDataNode,
           dropNode: abstractDropDataNode,
           dropPosition: 1,
         })
@@ -221,6 +227,7 @@ export function calcDropPosition(
     // 2. do not allow drop
     if (
       allowDrop({
+        dragNode: abstractDragDataNode,
         dropNode: abstractDropDataNode,
         dropPosition: 1,
       })
@@ -271,13 +278,11 @@ export function convertDataToTree(
 
   const { processProps = internalProcessProps } = processor || {};
   const list = Array.isArray(treeData) ? treeData : [treeData];
-  return list.map(
-    ({ children, ...props }): NodeElement => {
-      const childrenNodes = convertDataToTree(children, processor);
+  return list.map(({ children, ...props }): NodeElement => {
+    const childrenNodes = convertDataToTree(children, processor);
 
-      return <TreeNode {...processProps(props)}>{childrenNodes}</TreeNode>;
-    },
-  );
+    return <TreeNode {...processProps(props)}>{childrenNodes}</TreeNode>;
+  });
 }
 
 /**
@@ -334,7 +339,7 @@ export function conductExpandParent(keyList: Key[], keyEntities: Record<Key, Dat
     }
   }
 
-  (keyList || []).forEach((key) => {
+  (keyList || []).forEach(key => {
     conductUp(key);
   });
 
@@ -346,7 +351,7 @@ export function conductExpandParent(keyList: Key[], keyEntities: Record<Key, Dat
  */
 export function getDataAndAria(props: Partial<TreeProps | TreeNodeProps>) {
   const omitProps: Record<string, string> = {};
-  Object.keys(props).forEach((key) => {
+  Object.keys(props).forEach(key => {
     if (key.startsWith('data-') || key.startsWith('aria-')) {
       omitProps[key] = props[key];
     }

--- a/tests/Tree.spec.js
+++ b/tests/Tree.spec.js
@@ -1529,6 +1529,38 @@ describe('Tree Basic', () => {
           expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
           expect(onDrop.mock.calls[2][0].dropPosition).toEqual(1);
         });
+        it('allowDrop should pass dragNode and dropNode', () => {
+          const onDrop = jest.fn();
+          const allowDrop = jest.fn();
+          const wrapper = mount(
+            <Tree draggable defaultExpandAll allowDrop={allowDrop} onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-0" className="dragTarget">
+                <TreeNode key="0-0-0" className="dragTargetChild" />
+              </TreeNode>
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" className="dropTarget" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" />
+            </Tree>,
+          );
+          wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart', {
+            clientX: base * 500,
+            clientY: 500,
+          });
+          wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragEnter', {
+            clientX: base * 400,
+            clientY: 600,
+          });
+          wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragOver', {
+            clientX: base * 400,
+            clientY: 600,
+          });
+          wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('drop');
+          expect(allowDrop.mock.calls[0][0].dragNode.key).toEqual('0-0');
+          expect(allowDrop.mock.calls[0][0].dropNode.key).toEqual('0-1-0-0');
+        });
       });
     });
   });


### PR DESCRIPTION
Pass `dragNode` info when check `allowDrop` which can help us to decide which case should be allow trigger drop event