### PR TITLE
fix(tree-type): fix generic type for onCheck

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -131,7 +131,7 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
   ) => void;
   onCheck?: (
     checked: { checked: Key[]; halfChecked: Key[] } | Key[],
-    info: CheckInfo<BasicDataNode>,
+    info: CheckInfo<TreeDataType>,
   ) => void;
   onSelect?: (
     selectedKeys: Key[],


### PR DESCRIPTION
https://github.com/react-component/tree/pull/503 introduced generic types but the `onCheck` type was not set correctly