### PR TITLE
fixed the non draggable element did not hide the draggable icon

### DIFF
--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -334,7 +334,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
       context: { draggable, prefixCls },
     } = this.props;
 
-    return draggable?.icon ? (
+    return draggable?.icon && this.isDraggable() ? (
       <span className={`${prefixCls}-draggable-icon`}>{draggable.icon}</span>
     ) : null;
   };

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -1115,4 +1115,29 @@ describe('Tree Draggable', () => {
 
     expect(onDrop).toHaveBeenCalled();
   });
+
+  it('node is not draggable the draggable icon is not displayed', () => {
+    const { container } = render(
+      <Tree
+        draggable={{
+          icon: '↕️',
+          nodeDraggable: node => Array.isArray(node.children),
+        }}
+        defaultExpandAll
+        treeData={[
+          {
+            title: '0-0-label',
+            key: '0-0-key',
+            children: [
+              {
+                title: '0-0-0-label',
+                key: '0-0-0-key',
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/tests/__snapshots__/TreeDraggable.spec.tsx.snap
+++ b/tests/__snapshots__/TreeDraggable.spec.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tree Draggable node is not draggable the draggable icon is not displayed 1`] = `
+<div
+  class="rc-tree"
+  role="tree"
+>
+  <div>
+    <input
+      aria-label="for screen reader"
+      style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
+      tabindex="0"
+      value=""
+    />
+  </div>
+  <div
+    aria-hidden="true"
+    class="rc-tree-treenode"
+    style="position: absolute; pointer-events: none; visibility: hidden; height: 0px; overflow: hidden;"
+  >
+    <div
+      class="rc-tree-indent"
+    >
+      <div
+        class="rc-tree-indent-unit"
+      />
+    </div>
+  </div>
+  <div
+    class="rc-tree-list"
+    style="position: relative;"
+  >
+    <div
+      class="rc-tree-list-holder"
+    >
+      <div>
+        <div
+          class="rc-tree-list-holder-inner"
+          style="display: flex; flex-direction: column;"
+        >
+          <div
+            aria-grabbed="false"
+            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last rc-tree-treenode-draggable"
+            draggable="true"
+          >
+            <span
+              aria-hidden="true"
+              class="rc-tree-indent"
+            />
+            <span
+              class="rc-tree-draggable-icon"
+            >
+              ↕️
+            </span>
+            <span
+              class="rc-tree-switcher rc-tree-switcher_open"
+            />
+            <span
+              class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
+              title="0-0-label"
+            >
+              <span
+                class="rc-tree-iconEle rc-tree-icon__open"
+              />
+              <span
+                class="rc-tree-title"
+              >
+                0-0-label
+              </span>
+            </span>
+          </div>
+          <div
+            aria-grabbed="false"
+            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            draggable="false"
+          >
+            <span
+              aria-hidden="true"
+              class="rc-tree-indent"
+            >
+              <span
+                class="rc-tree-indent-unit rc-tree-indent-unit-start rc-tree-indent-unit-end"
+              />
+            </span>
+            <span
+              class="rc-tree-draggable-icon"
+            >
+              ↕️
+            </span>
+            <span
+              class="rc-tree-switcher rc-tree-switcher-noop"
+            />
+            <span
+              class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
+              title="0-0-0-label"
+            >
+              <span
+                class="rc-tree-iconEle rc-tree-icon__docu"
+              />
+              <span
+                class="rc-tree-title"
+              >
+                0-0-0-label
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/__snapshots__/TreeDraggable.spec.tsx.snap
+++ b/tests/__snapshots__/TreeDraggable.spec.tsx.snap
@@ -83,11 +83,6 @@ exports[`Tree Draggable node is not draggable the draggable icon is not displaye
               />
             </span>
             <span
-              class="rc-tree-draggable-icon"
-            >
-              ↕️
-            </span>
-            <span
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span


### PR DESCRIPTION

查看了 #523 解决方案，添加了一个 `classname`。

我个人觉得直接在 `renderDragHandler` 方法中直接判断是否可拖拽就好了。

解决 [ant-design#33708](https://github.com/ant-design/ant-design/issues/33708) 问题。