### PR TITLE
fix(ts): fix NodeListProps type error in ts@4.8.2

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import VirtualList, { ListRef } from 'rc-virtual-list';
-import { FlattenNode, Key, DataEntity, DataNode, ScrollTo } from './interface';
+import { FlattenNode, Key, DataEntity, DataNode, ScrollTo, BasicDataNode } from './interface';
 import MotionTreeNode from './MotionTreeNode';
 import { findExpandedKeys, getExpandRange } from './utils/diffUtil';
 import { getTreeNodeProps, getKey } from './utils/treeUtil';
@@ -54,7 +54,7 @@ export interface NodeListRef {
   getIndentWidth: () => number;
 }
 
-interface NodeListProps<TreeDataType> {
+interface NodeListProps<TreeDataType extends BasicDataNode> {
   prefixCls: string;
   style: React.CSSProperties;
   data: FlattenNode<TreeDataType>[];

--- a/tests/type.spec.tsx
+++ b/tests/type.spec.tsx
@@ -26,4 +26,20 @@ describe('Tree.TypeScript', () => {
       />,
     );
   });
+
+  it('throw error when DataType not extends BasicDataNode', () => {
+    // tsconfig default strict: false, null can assign to BasicDataNode, but will throw at runtime
+    const badData: BasicDataNode = null;
+
+    expect(() => {
+      render(
+        <Tree<BasicDataNode>
+          treeData={[badData]}
+          onSelect={(selectedKeys, info) => {
+            console.log('info', info);
+          }}
+        />,
+      );
+    }).toThrowError();
+  });
 });


### PR DESCRIPTION
Type error when use typescript@4.8,2

Reproduce:

- open https://replit.com/@jnhy/rc-tree-test and click run, then type `npm start` then enter
- or clone https://github.com/phyng/rc-tree-test to local and run `npm install && npm start`

Before:
![image](https://user-images.githubusercontent.com/5717770/187409140-50e0a9e7-daf7-46b7-b63a-382d072e5f83.png)

After:
![image](https://user-images.githubusercontent.com/5717770/187409246-9c63edf6-2c88-449b-8fbc-22d6c3189277.png)
