### PR TITLE
Activate item on select/check to do keyboard navigation onwards

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -169,6 +169,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   // =============================== Ref ================================
   const listRef = React.useRef<ListRef>(null);
   const indentMeasurerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
   React.useImperativeHandle(ref, () => ({
     scrollTo: scroll => {
       listRef.current.scrollTo(scroll);
@@ -252,6 +253,12 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
     }
   }, [dragging]);
 
+  React.useEffect(() => {
+    if (focused && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [focused]);
+
   const mergedData = motion ? transitionData : data;
 
   const treeNodeRequiredProps = {
@@ -281,6 +288,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
           tabIndex={focusable !== false ? tabIndex : null}
           onKeyDown={onKeyDown}
           onFocus={onFocus}
+          ref={inputRef}
           onBlur={onBlur}
           value=""
           onChange={noop}

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -357,9 +357,6 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
               onMotionStart={onListChangeStart}
               onMotionEnd={onMotionEnd}
               treeNodeRequiredProps={treeNodeRequiredProps}
-              onMouseMove={() => {
-                onActiveChange(null);
-              }}
             />
           );
         }}

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -858,6 +858,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       .filter(node => node);
 
     this.setUncontrolledState({ selectedKeys, focused: true });
+    this.onActiveChange(key)
 
     onSelect?.(selectedKeys, {
       event: 'select',
@@ -947,6 +948,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           halfCheckedKeys,
         },
       );
+      this.onActiveChange(key)
     }
 
     onCheck?.(checkedObj, eventObj as CheckInfo<TreeDataType>);

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -857,7 +857,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       })
       .filter(node => node);
 
-    this.setUncontrolledState({ selectedKeys });
+    this.setUncontrolledState({ selectedKeys, focused: true });
 
     onSelect?.(selectedKeys, {
       event: 'select',
@@ -940,6 +940,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       this.setUncontrolledState(
         {
           checkedKeys,
+          focused: true,
         },
         false,
         {


### PR DESCRIPTION
### Status Quo
The tree component allows to do keyboard navigation and mouse navigation.
If user uses the keyboard navigation (by tabbing on it) the tree item is shown active (not to be confused with _selected_).

### Problem
If user moves the mouse again, the active item is reset.
This might be annoying resp. not user-friendly, if the user wants to select a tree item and from there on use keyboard navigation.
 
### Motivation
User should be able to use keyboard and mouse navigation seamlessly, and not mutual exclusive.

### Solution
Do not reset the activate item, when mouse is moved.
Furthermore, set the active item, when user selects/checks a tree item.