### PR TITLE
chore: fix React 18.3 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "rc-dialog": "^8.1.0",
     "rc-tooltip": "5.x",
     "rc-trigger": "^5.0.7",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "typescript": "^4.0.2"
   },
   "dependencies": {

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -438,7 +438,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
   // Icon + Title
   renderSelector = () => {
     const { dragNodeHighlight } = this.state;
-    const { title, selected, icon, loading, data } = this.props;
+    const { title = defaultTitle, selected, icon, loading, data } = this.props;
     const {
       context: { prefixCls, showIcon, icon: treeIcon, loadData, titleRender },
     } = this.props;
@@ -620,9 +620,9 @@ const ContextTreeNode: React.FC<TreeNodeProps> = props => (
 
 ContextTreeNode.displayName = 'TreeNode';
 
-ContextTreeNode.defaultProps = {
-  title: defaultTitle,
-};
+// ContextTreeNode.defaultProps = {
+//   title: defaultTitle,
+// };
 
 (ContextTreeNode as any).isTreeNode = 1;
 

--- a/tests/React18.spec.tsx
+++ b/tests/React18.spec.tsx
@@ -1,8 +1,28 @@
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import Tree from '../src';
 
 describe('React 18', () => {
+  // This does not real work since waring is in 18.3.0 but current still is next version.
+  it('no warning', () => {
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <React.StrictMode>
+        <Tree
+          defaultExpandAll
+          treeData={[
+            {
+              title: 'Parent',
+              key: 'parent',
+            },
+          ]}
+        />
+      </React.StrictMode>,
+    );
+
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
   it('expand work', () => {
     const onExpand = jest.fn();
     const { container } = render(

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -1,22 +1,21 @@
 /* eslint-disable no-undef, react/no-multi-comp,
 react/no-unused-state, react/prop-types, no-return-assign */
-import React from 'react';
 import Tree, { TreeNode } from '../src';
 import {
-  convertDataToTree,
   conductExpandParent,
+  convertDataToTree,
   getDragChildrenKeys,
   parseCheckedKeys,
 } from '../src/util';
+import { conductCheck } from '../src/utils/conductUtil';
 import {
-  flattenTreeData,
-  convertTreeToData,
   convertDataToEntities,
+  convertTreeToData,
+  flattenTreeData,
   getTreeNodeProps,
   traverseDataNodes,
 } from '../src/utils/treeUtil';
 import { spyConsole, spyError } from './util';
-import { conductCheck } from '../src/utils/conductUtil';
 
 describe('Util', () => {
   spyConsole();
@@ -58,7 +57,7 @@ describe('Util', () => {
           },
         ],
       },
-      { key: '!', title: '---', really: true },
+      { key: '!', really: true },
     ]);
   });
 


### PR DESCRIPTION
现在 React 正式版是 18.2，测试实际上写了是测不出来，需要手工临时安装一下 React 18 next 版本才行。另外移除 WrapperNode 的 `defaultProps` 后会导致节点遍历时也就不会有这个值了，考虑到用户其实不会遍历 Tree children 并且还不设置 title，测试变化符合预期。

fix https://github.com/ant-design/ant-design/issues/41325