### PR TITLE
chore: remove duplicate property `dragNode` from `AllowDropOptions`

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -64,7 +64,6 @@ interface CheckInfo<TreeDataType extends BasicDataNode = DataNode> {
 }
 
 export interface AllowDropOptions<TreeDataType extends BasicDataNode = DataNode> {
-  dragNode: TreeDataType;
   dropNode: TreeDataType;
   dropPosition: -1 | 0 | 1;
 }


### PR DESCRIPTION
The title says it all.