### PR TITLE
fix: TreeNode false flicker in re-render

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -2,12 +2,13 @@
  * Handle virtual list of the TreeNodes.
  */
 
-import * as React from 'react';
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import VirtualList, { ListRef } from 'rc-virtual-list';
-import { BasicDataNode, FlattenNode, Key, DataEntity, DataNode, ScrollTo } from './interface';
+import * as React from 'react';
+import { BasicDataNode, DataEntity, DataNode, FlattenNode, Key, ScrollTo } from './interface';
 import MotionTreeNode from './MotionTreeNode';
 import { findExpandedKeys, getExpandRange } from './utils/diffUtil';
-import { getTreeNodeProps, getKey } from './utils/treeUtil';
+import { getKey, getTreeNodeProps } from './utils/treeUtil';
 
 const HIDDEN_STYLE = {
   width: 0,
@@ -199,7 +200,8 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   }
 
   // Do animation if expanded keys changed
-  React.useLayoutEffect(() => {
+  // layoutEffect here to avoid blink of node removing
+  useLayoutEffect(() => {
     setPrevExpandedKeys(expandedKeys);
 
     const diffExpanded = findExpandedKeys(prevExpandedKeys, expandedKeys);

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -199,7 +199,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   }
 
   // Do animation if expanded keys changed
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     setPrevExpandedKeys(expandedKeys);
 
     const diffExpanded = findExpandedKeys(prevExpandedKeys, expandedKeys);


### PR DESCRIPTION
fix [Tree 组件删除其中一个节点的时候页面会闪一下 ant-design/ant-design#41878](https://github.com/ant-design/ant-design/issues/41878)
> 我对react的了解并不是很深入，就这个问题的思考，如有问题可以及时和我沟通
* 我尝试去定位问题所在，发现页面闪烁是由于treeData发生变换之后 Inden 组件所接受的 level 发生了变化所导致的。
* 随后去定位 level 的变化发现 level 的值是通过 keyEntity 所获取的
* 我个人认为闪烁的原因是因为treeData发生更新后  tree 组件重新构造出新的 state，同时 state 下的 keyEntity 同样发生变化，由于 TreeNode 组件引入 keyEntity 是通过 Context 引入，因此在第一次更新阶段 level 发生变化，造成了 Inden 组件获取到更新后的 level造成了闪烁。而后续的第二次更新是由 NodeList 组件中的 useEffect 所产生，在第二次更新中对渲染 Tree 组件的 data 进行更新，随后删除了对应的节点
* 而 useLayoutEffct 好像本身便是处理该问题的 hook

> 在rc-tree库下，我通过了所有的测试用例。但在antd下的测试用例我无法进行准确的判断


closes #741 #742