### PR TITLE
fix: disabled motion will never end

### DIFF
--- a/docs/examples/animation.jsx
+++ b/docs/examples/animation.jsx
@@ -1,8 +1,9 @@
 /* eslint no-console:0, react/no-danger: 0 */
+import { Provider } from 'rc-motion';
+import Tree from 'rc-tree';
+import React from 'react';
 import '../../assets/index.less';
 import './animation.less';
-import React from 'react';
-import Tree from 'rc-tree';
 
 const STYLE = `
 .rc-tree-child-tree {
@@ -108,43 +109,56 @@ function getTreeData() {
 
 const Demo = () => {
   const treeRef = React.useRef();
+  const [motion, setMotion] = React.useState(true);
 
   setTimeout(() => {
     treeRef.current.scrollTo({ key: '0-9-2' });
   }, 100);
 
   return (
-    <div className="animation">
-      <h2>expanded</h2>
-      <style dangerouslySetInnerHTML={{ __html: STYLE }} />
+    <React.StrictMode>
+      <button
+        onClick={() => {
+          setMotion(m => !m);
+        }}
+      >
+        Motion: {String(motion)}
+      </button>
 
-      <div style={{ display: 'flex' }}>
-        <div style={{ flex: '1 1 50%' }}>
-          <h3>With Virtual</h3>
-          <Tree
-            ref={treeRef}
-            // defaultExpandAll={false}
-            defaultExpandAll
-            defaultExpandedKeys={defaultExpandedKeys}
-            motion={motion}
-            height={200}
-            itemHeight={20}
-            style={{ border: '1px solid #000' }}
-            treeData={getTreeData()}
-          />
+      <Provider motion={motion}>
+        <div className="animation">
+          <h2>expanded</h2>
+          <style dangerouslySetInnerHTML={{ __html: STYLE }} />
+
+          <div style={{ display: 'flex' }}>
+            <div style={{ flex: '1 1 50%' }}>
+              <h3>With Virtual</h3>
+              <Tree
+                ref={treeRef}
+                // defaultExpandAll={false}
+                defaultExpandAll
+                defaultExpandedKeys={defaultExpandedKeys}
+                motion={motion}
+                height={200}
+                itemHeight={20}
+                style={{ border: '1px solid #000' }}
+                treeData={getTreeData()}
+              />
+            </div>
+            <div style={{ flex: '1 1 50%' }}>
+              <h3>Without Virtual</h3>
+              <Tree
+                defaultExpandAll={false}
+                defaultExpandedKeys={defaultExpandedKeys}
+                motion={motion}
+                style={{ border: '1px solid #000' }}
+                treeData={getTreeData()}
+              />
+            </div>
+          </div>
         </div>
-        <div style={{ flex: '1 1 50%' }}>
-          <h3>Without Virtual</h3>
-          <Tree
-            defaultExpandAll={false}
-            defaultExpandedKeys={defaultExpandedKeys}
-            motion={motion}
-            style={{ border: '1px solid #000' }}
-            treeData={getTreeData()}
-          />
-        </div>
-      </div>
-    </div>
+      </Provider>
+    </React.StrictMode>
   );
 };
 

--- a/docs/examples/animation.jsx
+++ b/docs/examples/animation.jsx
@@ -109,23 +109,23 @@ function getTreeData() {
 
 const Demo = () => {
   const treeRef = React.useRef();
-  const [motion, setMotion] = React.useState(true);
+  const [enableMotion, setEnableMotion] = React.useState(true);
 
   setTimeout(() => {
     treeRef.current.scrollTo({ key: '0-9-2' });
   }, 100);
 
   return (
-    <React.StrictMode>
+    <Provider motion={enableMotion}>
       <button
         onClick={() => {
-          setMotion(m => !m);
+          setEnableMotion(e => !e);
         }}
       >
-        Motion: {String(motion)}
+        Motion: {String(enableMotion)}
       </button>
 
-      <Provider motion={motion}>
+      <React.StrictMode>
         <div className="animation">
           <h2>expanded</h2>
           <style dangerouslySetInnerHTML={{ __html: STYLE }} />
@@ -157,8 +157,8 @@ const Demo = () => {
             </div>
           </div>
         </div>
-      </Provider>
-    </React.StrictMode>
+      </React.StrictMode>
+    </Provider>
   );
 };
 

--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -33,8 +33,8 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
   },
   ref,
 ) => {
-  const { prefixCls } = React.useContext(TreeContext);
   const [visible, setVisible] = React.useState(true);
+  const { prefixCls } = React.useContext(TreeContext);
 
   useLayoutEffect(() => {
     if (motionNodes && motionType === 'hide' && visible) {
@@ -44,7 +44,6 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
 
   const onVisibleChanged = (nextVisible: boolean) => {
     if (visible === nextVisible) {
-      console.log('onVisibleChanged', nextVisible);
       onOriginMotionEnd();
     }
   };

--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -37,8 +37,12 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
   const { prefixCls } = React.useContext(TreeContext);
 
   useLayoutEffect(() => {
-    if (motionNodes && motionType === 'hide' && visible) {
-      setVisible(false);
+    if (motionNodes) {
+      onOriginMotionStart();
+
+      if (motionType === 'hide' && visible) {
+        setVisible(false);
+      }
     }
   }, [motionNodes]);
 

--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
-import { useEffect } from 'react';
 import classNames from 'classnames';
 import CSSMotion from 'rc-motion';
-import TreeNode from './TreeNode';
-import { FlattenNode, TreeNodeProps } from './interface';
-import { getTreeNodeProps, TreeNodeRequiredProps } from './utils/treeUtil';
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
+import * as React from 'react';
 import { TreeContext } from './contextTypes';
+import { FlattenNode, TreeNodeProps } from './interface';
+import TreeNode from './TreeNode';
+import { getTreeNodeProps, TreeNodeRequiredProps } from './utils/treeUtil';
 
 interface MotionTreeNodeProps extends Omit<TreeNodeProps, 'domRef'> {
   active: boolean;
@@ -33,42 +33,21 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
   },
   ref,
 ) => {
-  const [visible, setVisible] = React.useState(true);
   const { prefixCls } = React.useContext(TreeContext);
+  const [visible, setVisible] = React.useState(true);
 
-  const motionedRef = React.useRef(false);
-
-  const onMotionEnd = () => {
-    if (!motionedRef.current) {
-      onOriginMotionEnd();
-    }
-    motionedRef.current = true;
-  };
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (motionNodes && motionType === 'hide' && visible) {
       setVisible(false);
     }
   }, [motionNodes]);
 
-  let reruningEffectFlag = null;
-
-  useEffect(() => {
-    // Trigger motion only when patched
-    if (motionNodes) {
-      if (reruningEffectFlag === null) {
-        onOriginMotionStart();
-      } else {
-        clearTimeout(reruningEffectFlag);
-      }
+  const onVisibleChanged = (nextVisible: boolean) => {
+    if (visible === nextVisible) {
+      console.log('onVisibleChanged', nextVisible);
+      onOriginMotionEnd();
     }
-
-    return () => {
-      if (motionNodes) {
-        reruningEffectFlag = setTimeout(onMotionEnd, 0);
-      }
-    };
-  }, []);
+  };
 
   if (motionNodes) {
     return (
@@ -77,8 +56,7 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
         visible={visible}
         {...motion}
         motionAppear={motionType === 'show'}
-        onAppearEnd={onMotionEnd}
-        onLeaveEnd={onMotionEnd}
+        onVisibleChanged={onVisibleChanged}
       >
         {({ className: motionClassName, style: motionStyle }, motionRef) => (
           <div

--- a/src/useUnmount.ts
+++ b/src/useUnmount.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+/**
+ * Trigger only when component unmount
+ */
+export default function useUnmount(callback: VoidFunction) {
+  const [enabled, setEnabled] = React.useState(false);
+
+  React.useLayoutEffect(
+    () => () => {
+      if (enabled) {
+        callback();
+      }
+    },
+    [enabled],
+  );
+
+  React.useLayoutEffect(() => {
+    setEnabled(true);
+  }, []);
+}

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -1,8 +1,8 @@
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
-import Tree, { TreeNode, FieldDataNode } from '../src';
-import MotionTreeNode from '../src/MotionTreeNode';
+import Tree, { FieldDataNode, TreeNode } from '../src';
 import { TreeContext } from '../src/contextTypes';
+import MotionTreeNode from '../src/MotionTreeNode';
 import { getMinimumRangeTransitionRange } from '../src/NodeList';
 
 jest.mock('rc-motion/lib/util/motion', () => {
@@ -123,14 +123,20 @@ describe('Tree Motion', () => {
       const onMotionStart = jest.fn();
       const onMotionEnd = jest.fn();
       const { unmount } = render(
-        <TreeContext.Provider value={{ prefixCls: 'test' } as any}>
-          <MotionTreeNode
-            motionNodes={[]}
-            onMotionStart={onMotionStart}
-            onMotionEnd={onMotionEnd}
-            {...({} as any)} // Ignore TS warning
-          />
-        </TreeContext.Provider>,
+        <React.StrictMode>
+          <TreeContext.Provider value={{ prefixCls: 'test' } as any}>
+            <MotionTreeNode
+              motionNodes={[]}
+              onMotionStart={onMotionStart}
+              onMotionEnd={onMotionEnd}
+              motion={{
+                motionName: 'bamboo',
+              }}
+              motionType="hide"
+              {...({} as any)} // Ignore TS warning
+            />
+          </TreeContext.Provider>
+        </React.StrictMode>,
       );
 
       expect(onMotionStart).toHaveBeenCalled();
@@ -207,7 +213,7 @@ describe('Tree Motion', () => {
 
     const { container } = render(<Demo />);
     expect(container.querySelector('[title="B"]')).toBeTruthy();
-    // wrapper.find('.rc-tree-switcher').first().simulate('click');
+
     fireEvent.click(container.querySelector('.rc-tree-switcher'));
     act(() => {
       jest.runAllTimers();


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/43038

根本原因是 motion 默认为 `true`，通过 effect 切换为 `false` 会触发多个切换事件，只需要过滤无用事件即可。#735 用了 timeout，导致按帧计算时无动画时会被永久跳过。