### PR TITLE
fix: merge onMotionLogic into one set

### DIFF
--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -43,13 +43,17 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
 
   useLayoutEffect(() => {
     if (motionNodes) {
-      onOriginMotionStart();
-
       if (targetVisible !== visible) {
         setVisible(targetVisible);
       }
     }
   }, [motionNodes]);
+
+  const triggerMotionStart = () => {
+    if (motionNodes) {
+      onOriginMotionStart();
+    }
+  };
 
   // Should only trigger once
   const triggerMotionEndRef = React.useRef(false);
@@ -61,7 +65,7 @@ const MotionTreeNode: React.ForwardRefRenderFunction<HTMLDivElement, MotionTreeN
   };
 
   // Effect if unmount
-  useUnmount(triggerMotionEnd);
+  useUnmount(triggerMotionStart, triggerMotionEnd);
 
   // Motion end event
   const onVisibleChanged = (nextVisible: boolean) => {

--- a/src/useUnmount.ts
+++ b/src/useUnmount.ts
@@ -3,19 +3,24 @@ import * as React from 'react';
 /**
  * Trigger only when component unmount
  */
-export default function useUnmount(callback: VoidFunction) {
-  const [enabled, setEnabled] = React.useState(false);
-
-  React.useLayoutEffect(
-    () => () => {
-      if (enabled) {
-        callback();
-      }
-    },
-    [enabled],
-  );
+export default function useUnmount(triggerStart: VoidFunction, triggerEnd: VoidFunction) {
+  const [firstMount, setFirstMount] = React.useState(false);
 
   React.useLayoutEffect(() => {
-    setEnabled(true);
+    if (firstMount) {
+      triggerStart();
+
+      return () => {
+        triggerEnd();
+      };
+    }
+  }, [firstMount]);
+
+  React.useLayoutEffect(() => {
+    setFirstMount(true);
+
+    return () => {
+      setFirstMount(false);
+    };
   }, []);
 }

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -316,7 +316,10 @@ describe('Tree Motion', () => {
       />,
     );
 
-    console.log(container.innerHTML);
+    // Delay for clean up
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
 
     // Click should trigger event
     fireEvent.click(container.querySelector('.rc-tree-switcher_open'));

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -280,4 +280,46 @@ describe('Tree Motion', () => {
     expect(container.querySelectorAll('span.rc-tree-title')[0].textContent).toEqual('parent2');
     expect(container.querySelectorAll('span.rc-tree-title')[1].textContent).toEqual('child2');
   });
+
+  // https://github.com/ant-design/ant-design/issues/43282
+  it('dynamic modify data should stop motion', () => {
+    const motion = {
+      motionName: 'bamboo',
+    };
+
+    const getTreeData = () => [
+      {
+        title: 'parent',
+        key: 'parent',
+        children: [
+          {
+            title: 'child',
+            key: 'child',
+          },
+        ],
+      },
+    ];
+
+    const oriData = getTreeData();
+
+    const { container, rerender } = render(<Tree motion={motion} treeData={oriData} />);
+    rerender(<Tree motion={motion} treeData={oriData} expandedKeys={['parent']} />);
+
+    // Replace `treeData` before motion end
+    const onExpand = jest.fn();
+    rerender(
+      <Tree
+        onExpand={onExpand}
+        motion={motion}
+        treeData={getTreeData()}
+        expandedKeys={['parent']}
+      />,
+    );
+
+    console.log(container.innerHTML);
+
+    // Click should trigger event
+    fireEvent.click(container.querySelector('.rc-tree-switcher_open'));
+    expect(onExpand).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/43282

When in motion, dynamic modify `treeData` will block to make Tree always in motion status.