### PR TITLE
fix: Access CheckInfo interface for types when declaring onCheck handler

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -53,7 +53,7 @@ import DropIndicator from './DropIndicator';
 
 const MAX_RETRY_TIMES = 10;
 
-interface CheckInfo<TreeDataType extends BasicDataNode = DataNode> {
+export interface CheckInfo<TreeDataType extends BasicDataNode = DataNode> {
   event: 'check';
   node: EventDataNode<TreeDataType>;
   checked: boolean;


### PR DESCRIPTION
When implementing the onCheck handler, there are no accessible type definitions for the parameters at present.

![image](https://github.com/react-component/tree/assets/119929626/d99b5fcd-8b96-4039-a189-3ab6922b7c35)

