### PR TITLE
chore: follow up types update

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -5,7 +5,15 @@
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import VirtualList, { ListRef } from 'rc-virtual-list';
 import * as React from 'react';
-import { BasicDataNode, DataEntity, DataNode, FlattenNode, Key, ScrollTo } from './interface';
+import {
+  BasicDataNode,
+  DataEntity,
+  DataNode,
+  FlattenNode,
+  Key,
+  KeyEntities,
+  ScrollTo,
+} from './interface';
 import MotionTreeNode from './MotionTreeNode';
 import { findExpandedKeys, getExpandRange } from './utils/diffUtil';
 import { getKey, getTreeNodeProps } from './utils/treeUtil';
@@ -74,7 +82,7 @@ interface NodeListProps<TreeDataType extends BasicDataNode> {
   loadedKeys: Key[];
   loadingKeys: Key[];
   halfCheckedKeys: Key[];
-  keyEntities: Record<Key, DataEntity<any>>;
+  keyEntities: KeyEntities;
 
   dragging: boolean;
   dragOverNodeKey: Key;

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -41,6 +41,7 @@ import {
   posToArr,
 } from './util';
 import { conductCheck } from './utils/conductUtil';
+import getEntity from './utils/keyUtil';
 import {
   convertDataToEntities,
   convertNodePropsToEventData,
@@ -560,7 +561,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
         if (this.state.draggingNodeKey === null) return;
 
         let newExpandedKeys = [...expandedKeys];
-        const entity = keyEntities[node.props.eventKey];
+        const entity = getEntity(keyEntities, node.props.eventKey);
 
         if (entity && (entity.children || []).length) {
           newExpandedKeys = arrAdd(expandedKeys, node.props.eventKey);
@@ -736,7 +737,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     const abstractDropNodeProps = {
       ...getTreeNodeProps(dropTargetKey, this.getTreeNodeRequiredProps()),
       active: this.getActiveItem()?.key === dropTargetKey,
-      data: this.state.keyEntities[dropTargetKey].node,
+      data: getEntity(this.state.keyEntities, dropTargetKey).node,
     };
     const dropToChild = dragChildrenKeys.indexOf(dropTargetKey) !== -1;
 
@@ -850,7 +851,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     // [Legacy] Not found related usage in doc or upper libs
     const selectedNodes = selectedKeys
       .map(selectedKey => {
-        const entity = keyEntities[selectedKey];
+        const entity = getEntity(keyEntities, selectedKey);
         if (!entity) return null;
 
         return entity.node;
@@ -896,7 +897,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       checkedObj = { checked: checkedKeys, halfChecked: halfCheckedKeys };
 
       eventObj.checkedNodes = checkedKeys
-        .map(checkedKey => keyEntities[checkedKey])
+        .map(checkedKey => getEntity(keyEntities, checkedKey))
         .filter(entity => entity)
         .map(entity => entity.node);
 
@@ -928,7 +929,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       eventObj.halfCheckedKeys = halfCheckedKeys;
 
       checkedKeys.forEach(checkedKey => {
-        const entity = keyEntities[checkedKey];
+        const entity = getEntity(keyEntities, checkedKey);
         if (!entity) return;
 
         const { node, pos } = entity;

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -26,6 +26,7 @@ import {
   Key,
   KeyEntities,
   NodeInstance,
+  SafeKey,
   ScrollTo,
 } from './interface';
 import NodeList, { MotionEntity, MOTION_KEY, NodeListRef } from './NodeList';
@@ -261,9 +262,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   destroyed: boolean = false;
 
-  delayedDragEnterLogic: Record<Key, number>;
+  delayedDragEnterLogic: Record<SafeKey, number>;
 
-  loadingRetryTimes: Record<Key, number> = {};
+  loadingRetryTimes: Record<SafeKey, number> = {};
 
   state: TreeState<TreeDataType> = {
     keyEntities: {},
@@ -993,8 +994,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
             }));
 
             // If exceed max retry times, we give up retry
-            this.loadingRetryTimes[key] = (this.loadingRetryTimes[key] || 0) + 1;
-            if (this.loadingRetryTimes[key] >= MAX_RETRY_TIMES) {
+            this.loadingRetryTimes[key as SafeKey] =
+              (this.loadingRetryTimes[key as SafeKey] || 0) + 1;
+            if (this.loadingRetryTimes[key as SafeKey] >= MAX_RETRY_TIMES) {
               const { loadedKeys: currentLoadedKeys } = this.state;
 
               warning(false, 'Retry for `loadData` many times but still failed. No more retry.');

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1,55 +1,55 @@
 // TODO: https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/treeview/treeview-2/treeview-2a.html
 // Fully accessibility support
 
-import * as React from 'react';
-import KeyCode from 'rc-util/lib/KeyCode';
-import warning from 'rc-util/lib/warning';
-import pickAttrs from 'rc-util/lib/pickAttrs';
 import classNames from 'classnames';
+import KeyCode from 'rc-util/lib/KeyCode';
+import pickAttrs from 'rc-util/lib/pickAttrs';
+import warning from 'rc-util/lib/warning';
+import * as React from 'react';
 
 import {
-  TreeContext,
-  NodeMouseEventHandler,
   NodeDragEventHandler,
   NodeDragEventParams,
+  NodeMouseEventHandler,
   NodeMouseEventParams,
+  TreeContext,
 } from './contextTypes';
+import DropIndicator from './DropIndicator';
 import {
-  getDragChildrenKeys,
-  parseCheckedKeys,
-  conductExpandParent,
-  calcSelectedKeys,
-  calcDropPosition,
-  arrAdd,
-  arrDel,
-  posToArr,
-} from './util';
-import {
+  BasicDataNode,
   DataNode,
+  Direction,
+  EventDataNode,
+  FieldNames,
+  FlattenNode,
   IconType,
   Key,
-  FlattenNode,
-  DataEntity,
-  EventDataNode,
+  KeyEntities,
   NodeInstance,
   ScrollTo,
-  Direction,
-  FieldNames,
-  BasicDataNode,
 } from './interface';
-import {
-  flattenTreeData,
-  convertTreeToData,
-  convertDataToEntities,
-  warningWithoutKey,
-  convertNodePropsToEventData,
-  getTreeNodeProps,
-  fillFieldNames,
-} from './utils/treeUtil';
-import NodeList, { MOTION_KEY, MotionEntity, NodeListRef } from './NodeList';
+import NodeList, { MotionEntity, MOTION_KEY, NodeListRef } from './NodeList';
 import TreeNode from './TreeNode';
+import {
+  arrAdd,
+  arrDel,
+  calcDropPosition,
+  calcSelectedKeys,
+  conductExpandParent,
+  getDragChildrenKeys,
+  parseCheckedKeys,
+  posToArr,
+} from './util';
 import { conductCheck } from './utils/conductUtil';
-import DropIndicator from './DropIndicator';
+import {
+  convertDataToEntities,
+  convertNodePropsToEventData,
+  convertTreeToData,
+  fillFieldNames,
+  flattenTreeData,
+  getTreeNodeProps,
+  warningWithoutKey,
+} from './utils/treeUtil';
 
 const MAX_RETRY_TIMES = 10;
 
@@ -194,7 +194,7 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
 }
 
 interface TreeState<TreeDataType extends BasicDataNode = DataNode> {
-  keyEntities: Record<Key, DataEntity<TreeDataType>>;
+  keyEntities: KeyEntities<TreeDataType>;
 
   indent: number | null;
 
@@ -234,7 +234,7 @@ interface TreeState<TreeDataType extends BasicDataNode = DataNode> {
 class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends React.Component<
   TreeProps<TreeDataType>,
   TreeState<TreeDataType>
-  > {
+> {
   static defaultProps = {
     prefixCls: 'rc-tree',
     showLine: false,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -535,7 +535,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     } = this.props;
     const disabled = this.isDisabled();
     const dataOrAriaAttributeProps = pickAttrs(otherProps, { aria: true, data: true });
-    const { level } = keyEntities[eventKey] || {};
+    const { level } = getEntity(keyEntities, eventKey) || {};
     const isEndNode = isEnd[isEnd.length - 1];
 
     const mergedDraggable = this.isDraggable();

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { TreeContext, TreeContextProps } from './contextTypes';
 import Indent from './Indent';
 import { TreeNodeProps } from './interface';
+import getEntity from './utils/keyUtil';
 import { convertNodePropsToEventData } from './utils/treeUtil';
 
 const ICON_OPEN = 'open';
@@ -209,7 +210,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     const {
       context: { keyEntities },
     } = this.props;
-    const { children } = keyEntities[eventKey] || {};
+    const { children } = getEntity(keyEntities, eventKey) || {};
 
     return !!(children || []).length;
   };

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -4,14 +4,13 @@
  */
 import * as React from 'react';
 import {
-  IconType,
-  Key,
-  DataEntity,
-  EventDataNode,
-  NodeInstance,
+  BasicDataNode,
   DataNode,
   Direction,
-  BasicDataNode,
+  EventDataNode,
+  IconType,
+  KeyEntities,
+  NodeInstance,
 } from './interface';
 import { DraggableConfig } from './Tree';
 
@@ -46,15 +45,15 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
   icon: IconType;
   switcherIcon: IconType;
   draggable?: DraggableConfig;
-  draggingNodeKey?: Key;
+  draggingNodeKey?: React.Key;
   checkable: boolean | React.ReactNode;
   checkStrictly: boolean;
   disabled: boolean;
-  keyEntities: Record<Key, DataEntity<any>>;
+  keyEntities: KeyEntities;
   // for details see comment in Tree.state (Tree.tsx)
   dropLevelOffset?: number;
-  dropContainerKey: Key | null;
-  dropTargetKey: Key | null;
+  dropContainerKey: React.Key | null;
+  dropTargetKey: React.Key | null;
   dropPosition: -1 | 0 | 1 | null;
   indent: number | null;
   dropIndicatorRender: (props: {
@@ -64,7 +63,7 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
     prefixCls;
     direction: Direction;
   }) => React.ReactNode;
-  dragOverNodeKey: Key | null;
+  dragOverNodeKey: React.Key | null;
   direction: Direction;
 
   loadData: (treeNode: EventDataNode<TreeDataType>) => Promise<void>;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -9,6 +9,7 @@ import {
   Direction,
   EventDataNode,
   IconType,
+  Key,
   KeyEntities,
   NodeInstance,
 } from './interface';
@@ -45,15 +46,15 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
   icon: IconType;
   switcherIcon: IconType;
   draggable?: DraggableConfig;
-  draggingNodeKey?: React.Key;
+  draggingNodeKey?: Key;
   checkable: boolean | React.ReactNode;
   checkStrictly: boolean;
   disabled: boolean;
   keyEntities: KeyEntities;
   // for details see comment in Tree.state (Tree.tsx)
   dropLevelOffset?: number;
-  dropContainerKey: React.Key | null;
-  dropTargetKey: React.Key | null;
+  dropContainerKey: Key | null;
+  dropTargetKey: Key | null;
   dropPosition: -1 | 0 | 1 | null;
   indent: number | null;
   dropIndicatorRender: (props: {
@@ -63,7 +64,7 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
     prefixCls;
     direction: Direction;
   }) => React.ReactNode;
-  dragOverNodeKey: React.Key | null;
+  dragOverNodeKey: Key | null;
   direction: Direction;
 
   loadData: (treeNode: EventDataNode<TreeDataType>) => Promise<void>;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export { ScrollTo } from 'rc-virtual-list/lib/List';
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
-  eventKey?: Key; // Pass by parent `cloneElement`
+  eventKey?: React.Key; // Pass by parent `cloneElement`
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
@@ -59,15 +59,15 @@ export type FieldDataNode<T, ChildFieldName extends string = 'children'> = Basic
   T &
   Partial<Record<ChildFieldName, FieldDataNode<T, ChildFieldName>[]>>;
 
-export type Key = string | number;
+export type KeyEntities<DateType = any> = Record<string | number, DataEntity<DateType>>;
 
 export type DataNode = FieldDataNode<{
-  key: Key;
+  key: React.Key;
   title?: React.ReactNode | ((data: DataNode) => React.ReactNode);
 }>;
 
 export type EventDataNode<TreeDataType> = {
-  key: Key;
+  key: React.Key;
   expanded: boolean;
   selected: boolean;
   checked: boolean;
@@ -100,7 +100,7 @@ export type NodeInstance<TreeDataType extends BasicDataNode = DataNode> = React.
 export interface Entity {
   node: NodeElement;
   index: number;
-  key: Key;
+  key: React.Key;
   pos: string;
   parent?: Entity;
   children?: Entity[];
@@ -121,12 +121,12 @@ export interface FlattenNode<TreeDataType extends BasicDataNode = DataNode> {
   pos: string;
   data: TreeDataType;
   title: React.ReactNode;
-  key: Key;
+  key: React.Key;
   isStart: boolean[];
   isEnd: boolean[];
 }
 
-export type GetKey<RecordType> = (record: RecordType, index?: number) => Key;
+export type GetKey<RecordType> = (record: RecordType, index?: number) => React.Key;
 
 export type GetCheckDisabled<RecordType> = (record: RecordType) => boolean;
 

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export { ScrollTo } from 'rc-virtual-list/lib/List';
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
-  eventKey?: React.Key; // Pass by parent `cloneElement`
+  eventKey?: Key; // Pass by parent `cloneElement`
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
@@ -59,15 +59,23 @@ export type FieldDataNode<T, ChildFieldName extends string = 'children'> = Basic
   T &
   Partial<Record<ChildFieldName, FieldDataNode<T, ChildFieldName>[]>>;
 
-export type KeyEntities<DateType = any> = Record<string | number, DataEntity<DateType>>;
+export type Key = React.Key;
+
+/**
+ * Typescript not support `bigint` as index type yet.
+ * We use this to mark the `bigint` type is for `Key` usage.
+ */
+export type SafeKey = Exclude<Key, bigint>;
+
+export type KeyEntities<DateType = any> = Record<SafeKey, DataEntity<DateType>>;
 
 export type DataNode = FieldDataNode<{
-  key: React.Key;
+  key: Key;
   title?: React.ReactNode | ((data: DataNode) => React.ReactNode);
 }>;
 
 export type EventDataNode<TreeDataType> = {
-  key: React.Key;
+  key: Key;
   expanded: boolean;
   selected: boolean;
   checked: boolean;
@@ -100,7 +108,7 @@ export type NodeInstance<TreeDataType extends BasicDataNode = DataNode> = React.
 export interface Entity {
   node: NodeElement;
   index: number;
-  key: React.Key;
+  key: Key;
   pos: string;
   parent?: Entity;
   children?: Entity[];
@@ -121,12 +129,12 @@ export interface FlattenNode<TreeDataType extends BasicDataNode = DataNode> {
   pos: string;
   data: TreeDataType;
   title: React.ReactNode;
-  key: React.Key;
+  key: Key;
   isStart: boolean[];
   isEnd: boolean[];
 }
 
-export type GetKey<RecordType> = (record: RecordType, index?: number) => React.Key;
+export type GetKey<RecordType> = (record: RecordType, index?: number) => Key;
 
 export type GetCheckDisabled<RecordType> = (record: RecordType) => boolean;
 

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -64,6 +64,8 @@ export type Key = React.Key;
 /**
  * Typescript not support `bigint` as index type yet.
  * We use this to mark the `bigint` type is for `Key` usage.
+ * It's safe to remove this when typescript fix:
+ * https://github.com/microsoft/TypeScript/issues/50217
  */
 export type SafeKey = Exclude<Key, bigint>;
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -3,20 +3,21 @@
  * Legacy code. Should avoid to use if you are new to import these code.
  */
 
-import React from 'react';
 import warning from 'rc-util/lib/warning';
-import TreeNode from './TreeNode';
+import React from 'react';
 import {
-  NodeElement,
-  Key,
-  DataNode,
-  DataEntity,
-  NodeInstance,
-  FlattenNode,
-  Direction,
   BasicDataNode,
+  DataEntity,
+  DataNode,
+  Direction,
+  FlattenNode,
+  Key,
+  KeyEntities,
+  NodeElement,
+  NodeInstance,
 } from './interface';
-import { TreeProps, AllowDrop } from './Tree';
+import { AllowDrop, TreeProps } from './Tree';
+import TreeNode from './TreeNode';
 
 export { getPosition, isTreeNode } from './utils/treeUtil';
 
@@ -44,7 +45,7 @@ export function posToArr(pos: string) {
 
 export function getDragChildrenKeys<TreeDataType extends BasicDataNode = DataNode>(
   dragNodeKey: Key,
-  keyEntities: Record<Key, DataEntity<TreeDataType>>,
+  keyEntities: KeyEntities<TreeDataType>,
 ): Key[] {
   // not contains self
   // self for left or right drag
@@ -92,7 +93,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   },
   allowDrop: AllowDrop<TreeDataType>,
   flattenedNodes: FlattenNode<TreeDataType>[],
-  keyEntities: Record<Key, DataEntity<TreeDataType>>,
+  keyEntities: KeyEntities<TreeDataType>,
   expandKeys: Key[],
   direction: Direction,
 ): {
@@ -326,7 +327,7 @@ export function parseCheckedKeys(keys: Key[] | { checked: Key[]; halfChecked: Ke
  * @param keyList
  * @param keyEntities
  */
-export function conductExpandParent(keyList: Key[], keyEntities: Record<Key, DataEntity>): Key[] {
+export function conductExpandParent(keyList: Key[], keyEntities: KeyEntities<DataEntity>): Key[] {
   const expandedKeys = new Set<Key>();
 
   function conductUp(key: Key) {

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -15,6 +15,7 @@ import {
   KeyEntities,
   NodeElement,
   NodeInstance,
+  SafeKey,
 } from './interface';
 import { AllowDrop, TreeProps } from './Tree';
 import TreeNode from './TreeNode';
@@ -51,7 +52,7 @@ export function getDragChildrenKeys<TreeDataType extends BasicDataNode = DataNod
   // self for left or right drag
   const dragChildrenKeys = [];
 
-  const entity = keyEntities[dragNodeKey];
+  const entity = keyEntities[dragNodeKey as SafeKey];
   function dig(list: DataEntity<TreeDataType>[] = []) {
     list.forEach(({ key, children }) => {
       dragChildrenKeys.push(key);
@@ -113,7 +114,8 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   const rawDropLevelOffset = (horizontalMouseOffset - 12) / indent;
 
   // find abstract drop node by horizontal offset
-  let abstractDropNodeEntity: DataEntity<TreeDataType> = keyEntities[targetNode.props.eventKey];
+  let abstractDropNodeEntity: DataEntity<TreeDataType> =
+    keyEntities[targetNode.props.eventKey as SafeKey];
 
   if (clientY < top + height / 2) {
     // first half, set abstract drop node to previous node
@@ -122,7 +124,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
     );
     const prevNodeIndex = nodeIndex <= 0 ? 0 : nodeIndex - 1;
     const prevNodeKey = flattenedNodes[prevNodeIndex].key;
-    abstractDropNodeEntity = keyEntities[prevNodeKey];
+    abstractDropNodeEntity = keyEntities[prevNodeKey as SafeKey];
   }
 
   const initialAbstractDropNodeKey = abstractDropNodeEntity.key;
@@ -327,13 +329,13 @@ export function parseCheckedKeys(keys: Key[] | { checked: Key[]; halfChecked: Ke
  * @param keyList
  * @param keyEntities
  */
-export function conductExpandParent(keyList: Key[], keyEntities: KeyEntities<DataEntity>): Key[] {
+export function conductExpandParent(keyList: Key[], keyEntities: KeyEntities): Key[] {
   const expandedKeys = new Set<Key>();
 
   function conductUp(key: Key) {
     if (expandedKeys.has(key)) return;
 
-    const entity = keyEntities[key];
+    const entity = keyEntities[key as SafeKey];
     if (!entity) return;
 
     expandedKeys.add(key);

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -15,10 +15,10 @@ import {
   KeyEntities,
   NodeElement,
   NodeInstance,
-  SafeKey,
 } from './interface';
 import { AllowDrop, TreeProps } from './Tree';
 import TreeNode from './TreeNode';
+import getEntity from './utils/keyUtil';
 
 export { getPosition, isTreeNode } from './utils/treeUtil';
 
@@ -52,7 +52,7 @@ export function getDragChildrenKeys<TreeDataType extends BasicDataNode = DataNod
   // self for left or right drag
   const dragChildrenKeys = [];
 
-  const entity = keyEntities[dragNodeKey as SafeKey];
+  const entity = getEntity(keyEntities, dragNodeKey);
   function dig(list: DataEntity<TreeDataType>[] = []) {
     list.forEach(({ key, children }) => {
       dragChildrenKeys.push(key);
@@ -114,8 +114,10 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   const rawDropLevelOffset = (horizontalMouseOffset - 12) / indent;
 
   // find abstract drop node by horizontal offset
-  let abstractDropNodeEntity: DataEntity<TreeDataType> =
-    keyEntities[targetNode.props.eventKey as SafeKey];
+  let abstractDropNodeEntity: DataEntity<TreeDataType> = getEntity(
+    keyEntities,
+    targetNode.props.eventKey,
+  );
 
   if (clientY < top + height / 2) {
     // first half, set abstract drop node to previous node
@@ -124,7 +126,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
     );
     const prevNodeIndex = nodeIndex <= 0 ? 0 : nodeIndex - 1;
     const prevNodeKey = flattenedNodes[prevNodeIndex].key;
-    abstractDropNodeEntity = keyEntities[prevNodeKey as SafeKey];
+    abstractDropNodeEntity = getEntity(keyEntities, prevNodeKey);
   }
 
   const initialAbstractDropNodeKey = abstractDropNodeEntity.key;
@@ -335,7 +337,7 @@ export function conductExpandParent(keyList: Key[], keyEntities: KeyEntities): K
   function conductUp(key: Key) {
     if (expandedKeys.has(key)) return;
 
-    const entity = keyEntities[key as SafeKey];
+    const entity = getEntity(keyEntities, key);
     if (!entity) return;
 
     expandedKeys.add(key);

--- a/src/utils/conductUtil.ts
+++ b/src/utils/conductUtil.ts
@@ -6,8 +6,8 @@ import {
   GetCheckDisabled,
   Key,
   KeyEntities,
-  SafeKey,
 } from '../interface';
+import getEntity from './keyUtil';
 
 interface ConductReturnType {
   checkedKeys: Key[];
@@ -208,7 +208,7 @@ export function conductCheck<TreeDataType extends BasicDataNode = DataNode>(
   // We only handle exist keys
   const keys = new Set<Key>(
     keyList.filter(key => {
-      const hasEntity = !!keyEntities[key as SafeKey];
+      const hasEntity = !!getEntity(keyEntities, key);
       if (!hasEntity) {
         warningMissKeys.push(key);
       }

--- a/src/utils/conductUtil.ts
+++ b/src/utils/conductUtil.ts
@@ -1,5 +1,5 @@
 import warning from 'rc-util/lib/warning';
-import { Key, DataEntity, DataNode, GetCheckDisabled, BasicDataNode } from '../interface';
+import { Key, DataEntity, DataNode, GetCheckDisabled, BasicDataNode, KeyEntities } from '../interface';
 
 interface ConductReturnType {
   checkedKeys: Key[];
@@ -185,7 +185,7 @@ function cleanConductCheck<TreeDataType extends BasicDataNode = DataNode>(
 export function conductCheck<TreeDataType extends BasicDataNode = DataNode>(
   keyList: Key[],
   checked: true | { checked: false; halfCheckedKeys: Key[] },
-  keyEntities: Record<Key, DataEntity<TreeDataType>>,
+  keyEntities: KeyEntities<TreeDataType>,
   getCheckDisabled?: GetCheckDisabled<TreeDataType>,
 ): ConductReturnType {
   const warningMissKeys: Key[] = [];

--- a/src/utils/conductUtil.ts
+++ b/src/utils/conductUtil.ts
@@ -1,5 +1,13 @@
 import warning from 'rc-util/lib/warning';
-import { Key, DataEntity, DataNode, GetCheckDisabled, BasicDataNode, KeyEntities } from '../interface';
+import {
+  BasicDataNode,
+  DataEntity,
+  DataNode,
+  GetCheckDisabled,
+  Key,
+  KeyEntities,
+  SafeKey,
+} from '../interface';
 
 interface ConductReturnType {
   checkedKeys: Key[];
@@ -200,7 +208,7 @@ export function conductCheck<TreeDataType extends BasicDataNode = DataNode>(
   // We only handle exist keys
   const keys = new Set<Key>(
     keyList.filter(key => {
-      const hasEntity = !!keyEntities[key];
+      const hasEntity = !!keyEntities[key as SafeKey];
       if (!hasEntity) {
         warningMissKeys.push(key);
       }

--- a/src/utils/keyUtil.ts
+++ b/src/utils/keyUtil.ts
@@ -1,0 +1,5 @@
+import type { Key, KeyEntities, SafeKey } from '../interface';
+
+export default function getEntity<T = any>(keyEntities: KeyEntities<T>, key: Key) {
+  return keyEntities[key as SafeKey];
+}

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -16,6 +16,7 @@ import {
   SafeKey,
   TreeNodeProps,
 } from '../interface';
+import getEntity from './keyUtil';
 
 export function getPosition(level: string | number, index: number) {
   return `${level}-${index}`;
@@ -380,7 +381,7 @@ export function getTreeNodeProps<TreeDataType extends BasicDataNode = DataNode>(
     keyEntities,
   }: TreeNodeRequiredProps<TreeDataType>,
 ) {
-  const entity = keyEntities[key as SafeKey];
+  const entity = getEntity(keyEntities, key);
 
   const treeNodeProps = {
     eventKey: key,

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -11,6 +11,7 @@ import {
   FlattenNode,
   GetKey,
   Key,
+  KeyEntities,
   NodeElement,
   TreeNodeProps,
 } from '../interface';
@@ -277,7 +278,7 @@ export function traverseDataNodes(
 
 interface Wrapper {
   posEntities: Record<string, DataEntity>;
-  keyEntities: Record<Key, DataEntity>;
+  keyEntities: KeyEntities;
 }
 
 /**

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -13,6 +13,7 @@ import {
   Key,
   KeyEntities,
   NodeElement,
+  SafeKey,
   TreeNodeProps,
 } from '../interface';
 
@@ -327,7 +328,7 @@ export function convertDataToEntities(
       const mergedKey = getKey(key, pos);
 
       posEntities[pos] = entity;
-      keyEntities[mergedKey] = entity;
+      keyEntities[mergedKey as SafeKey] = entity;
 
       // Fill children
       entity.parent = posEntities[parentPos];
@@ -359,7 +360,7 @@ export interface TreeNodeRequiredProps<TreeDataType extends BasicDataNode = Data
   halfCheckedKeys: Key[];
   dragOverNodeKey: Key;
   dropPosition: number;
-  keyEntities: Record<Key, DataEntity<TreeDataType>>;
+  keyEntities: KeyEntities<TreeDataType>;
 }
 
 /**
@@ -379,7 +380,7 @@ export function getTreeNodeProps<TreeDataType extends BasicDataNode = DataNode>(
     keyEntities,
   }: TreeNodeRequiredProps<TreeDataType>,
 ) {
-  const entity = keyEntities[key];
+  const entity = keyEntities[key as SafeKey];
 
   const treeNodeProps = {
     eventKey: key,


### PR DESCRIPTION
对外接口对齐 React.Key，内部抽出 KeyEntities 定义和转化方法。等 TS 支持 bigint 类型，可以做统一处理。

ref https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66723