### PR TITLE
Improve type information for onClick and onDoubleClick handlers

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -124,8 +124,8 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
   onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
-  onClick?: NodeMouseEventHandler;
-  onDoubleClick?: NodeMouseEventHandler;
+  onClick?: NodeMouseEventHandler<TreeDataType>;
+  onDoubleClick?: NodeMouseEventHandler<TreeDataType>;
   onScroll?: React.UIEventHandler<HTMLElement>;
   onExpand?: (
     expandedKeys: Key[],

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -812,7 +812,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     this.onNodeExpand(e as React.MouseEvent<HTMLDivElement>, eventNode);
   };
 
-  onNodeClick: NodeMouseEventHandler = (e, treeNode) => {
+  onNodeClick: NodeMouseEventHandler<TreeDataType> = (e, treeNode) => {
     const { onClick, expandAction } = this.props;
 
     if (expandAction === 'click') {
@@ -822,7 +822,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     onClick?.(e, treeNode);
   };
 
-  onNodeDoubleClick: NodeMouseEventHandler = (e, treeNode) => {
+  onNodeDoubleClick: NodeMouseEventHandler<TreeDataType> = (e, treeNode) => {
     const { onDoubleClick, expandAction } = this.props;
 
     if (expandAction === 'doubleClick') {


### PR DESCRIPTION
Improve type information for onClick and onDoubleClick handlers.  Pass through generics.

Before:

![image](https://github.com/react-component/tree/assets/119929626/efd5f411-dd73-47bb-b0ab-15301cec09ac)


After:

![image](https://github.com/react-component/tree/assets/119929626/25cab1de-d69a-4e71-abed-e4b8f5d2b786)
