### PR TITLE
Fix async issue with scrollTo test

### DIFF
--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp, no-console,
 react/no-unused-state, react/prop-types, no-return-assign */
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import {render, fireEvent, act} from '@testing-library/react';
 import { resetWarned } from 'rc-util/lib/warning';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import Tree, { TreeNode } from '../src';
@@ -1054,7 +1054,10 @@ describe('Tree Basic', () => {
       const treeRef = React.createRef<any>();
       render(<Tree ref={treeRef} />);
 
-      treeRef.current.scrollTo({ key: 'light', align: 'top' });
+      act(() => {
+        treeRef.current.scrollTo({key: 'light', align: 'top'});
+      });
+      
       jest.runAllTimers();
 
       expect(called).toBeTruthy();


### PR DESCRIPTION
The implementation of rc-virtual-list has changed and is more async.  Fixed the associated test by adding act.  This is what they've done in the rc-virtual-list tests too:

https://github.com/react-component/virtual-list/blob/baf75273ba1f6106b87c635b9b951466537646d7/tests/scroll.test.js#L101