### PR TITLE
Webpack 4 and Node 17 incompatibility fix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+﻿node-options="--openssl-legacy-provider"


### PR DESCRIPTION
Webpack 4 requires this workaround in order to work with node 17+.  This should fix the Vercel deploys.