### PR TITLE
fix: Drag over expanded empty node should work as normal node

### DIFF
--- a/docs/examples/draggable.jsx
+++ b/docs/examples/draggable.jsx
@@ -7,30 +7,6 @@ import { generateData } from './utils/dataUtil';
 
 const gData = generateData(2, 2, 2);
 
-const defaultTreeNodes = [
-  {
-    key: 1,
-    title: 'p1',
-    children: [
-      {
-        key: 2,
-        title: 'p2',
-        children: [],
-      },
-    ],
-  },
-  {
-    key: 3,
-    title: 'p3',
-    children: [],
-  },
-  {
-    key: 4,
-    title: 'p4',
-    children: [],
-  },
-];
-
 class Demo extends React.Component {
   state = {
     gData,
@@ -131,19 +107,16 @@ class Demo extends React.Component {
         <p>drag a node into another node</p>
         <div style={{ border: '1px solid red' }}>
           <Tree
-            defaultExpandAll
-            // expandedKeys={[1]}
-            // expandedKeys={this.state.expandedKeys}
+            expandedKeys={this.state.expandedKeys}
             onExpand={this.onExpand}
-            // autoExpandParent={this.state.autoExpandParent}
+            autoExpandParent={this.state.autoExpandParent}
             draggable={{
               icon: '↕️',
             }}
             onDragStart={this.onDragStart}
             onDragEnter={this.onDragEnter}
             onDrop={this.onDrop}
-            onDragOver={console.error}
-            treeData={defaultTreeNodes}
+            treeData={this.state.gData}
             // Virtual
             height={200}
             itemHeight={20}

--- a/docs/examples/draggable.jsx
+++ b/docs/examples/draggable.jsx
@@ -1,11 +1,35 @@
 /* eslint-disable no-console, react/no-access-state-in-setstate */
 import React from 'react';
-import { generateData } from './utils/dataUtil';
-import './draggable.less';
 import '../../assets/index.less';
 import Tree from '../../src';
+import './draggable.less';
+import { generateData } from './utils/dataUtil';
 
 const gData = generateData(2, 2, 2);
+
+const defaultTreeNodes = [
+  {
+    key: 1,
+    title: 'p1',
+    children: [
+      {
+        key: 2,
+        title: 'p2',
+        children: [],
+      },
+    ],
+  },
+  {
+    key: 3,
+    title: 'p3',
+    children: [],
+  },
+  {
+    key: 4,
+    title: 'p4',
+    children: [],
+  },
+];
 
 class Demo extends React.Component {
   state = {
@@ -107,16 +131,19 @@ class Demo extends React.Component {
         <p>drag a node into another node</p>
         <div style={{ border: '1px solid red' }}>
           <Tree
-            expandedKeys={this.state.expandedKeys}
+            defaultExpandAll
+            // expandedKeys={[1]}
+            // expandedKeys={this.state.expandedKeys}
             onExpand={this.onExpand}
-            autoExpandParent={this.state.autoExpandParent}
+            // autoExpandParent={this.state.autoExpandParent}
             draggable={{
               icon: '↕️',
             }}
             onDragStart={this.onDragStart}
             onDragEnter={this.onDragEnter}
             onDrop={this.onDrop}
-            treeData={this.state.gData}
+            onDragOver={console.error}
+            treeData={defaultTreeNodes}
             // Virtual
             height={200}
             itemHeight={20}

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -397,7 +397,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
-      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => cloneKeyEntities[key].key);
+      newState.expandedKeys = Object.keys(cloneKeyEntities)
+        .map(key => cloneKeyEntities[key].key);
+      console.log('>>>', newState.expandedKeys, cloneKeyEntities);
     } else if (!prevProps && props.defaultExpandedKeys) {
       newState.expandedKeys =
         props.autoExpandParent || props.defaultExpandParent

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -397,9 +397,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
-      newState.expandedKeys = Object.keys(cloneKeyEntities)
-        .map(key => cloneKeyEntities[key].key);
-      console.log('>>>', newState.expandedKeys, cloneKeyEntities);
+      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => cloneKeyEntities[key].key);
     } else if (!prevProps && props.defaultExpandedKeys) {
       newState.expandedKeys =
         props.autoExpandParent || props.defaultExpandParent
@@ -639,7 +637,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
     if (dragChildrenKeys.indexOf(dropTargetKey) !== -1 || !dropAllowed) {
       // don't allow drop inside its children
-      // don't allow drop when drop is not allowed caculated by calcDropPosition
+      // don't allow drop when drop is not allowed calculated by calcDropPosition
       return;
     }
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -113,6 +113,9 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
     (direction === 'rtl' ? -1 : 1) * ((startMousePosition?.x || 0) - clientX);
   const rawDropLevelOffset = (horizontalMouseOffset - 12) / indent;
 
+  // Filter the expanded keys to exclude the node that not has children currently (like async nodes).
+  const filteredExpandKeys = expandKeys.filter((key: string) => keyEntities[key]?.children?.length);
+
   // find abstract drop node by horizontal offset
   let abstractDropNodeEntity: DataEntity<TreeDataType> = getEntity(
     keyEntities,
@@ -138,7 +141,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   let dropLevelOffset = 0;
 
   // Only allow cross level drop when dragging on a non-expanded node
-  if (!expandKeys.includes(initialAbstractDropNodeKey)) {
+  if (!filteredExpandKeys.includes(initialAbstractDropNodeKey)) {
     for (let i = 0; i < rawDropLevelOffset; i += 1) {
       if (isLastChild(abstractDropNodeEntity)) {
         abstractDropNodeEntity = abstractDropNodeEntity.parent;
@@ -167,7 +170,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
     dropPosition = -1;
   } else if (
     (abstractDragOverEntity.children || []).length &&
-    expandKeys.includes(dragOverNodeKey)
+    filteredExpandKeys.includes(dragOverNodeKey)
   ) {
     // drop on expanded node
     // only allow drop inside

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable no-undef, react/no-multi-comp, no-console,
 react/no-unused-state, react/prop-types, no-return-assign */
-import React from 'react';
-import { render, fireEvent, act, createEvent } from '@testing-library/react';
+import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
-import Tree, { TreeNode, FieldDataNode } from '../src';
+import Tree, { FieldDataNode, TreeNode, TreeProps } from '../src';
 import { spyConsole } from './util';
 
 const delay = timeout =>
@@ -14,7 +13,7 @@ const delay = timeout =>
 describe('Tree Draggable', () => {
   spyConsole();
 
-  function createTree(props?: any) {
+  function createTree(props?: Partial<TreeProps>) {
     return (
       <Tree draggable defaultExpandAll {...props}>
         <TreeNode title="parent 1" key="0-0">
@@ -1146,5 +1145,43 @@ describe('Tree Draggable', () => {
       </Tree>,
     );
     expect(container.querySelectorAll('.rc-tree-treenode-draggable').length).toBe(3);
+  });
+
+  it('not conflict with defaultExpandAll', () => {
+    const treeData = [
+      {
+        key: 1,
+        title: 'p1',
+        children: [
+          {
+            key: 2,
+            title: 'p2',
+            children: [],
+            className: 'dropTarget',
+          },
+        ],
+      },
+      {
+        key: 3,
+        title: 'p3',
+        children: [],
+      },
+      {
+        key: 4,
+        title: 'p4',
+        children: [],
+        className: 'dragTarget',
+      },
+    ];
+
+    const { container } = render(createTree({ defaultExpandAll: true, treeData }));
+    fireEvent.dragStart(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
+
+    // Drag over
+    const event = createEvent.dragOver(container.querySelector('.dropTarget'));
+    Object.defineProperty(event, 'clientX', { value: -9999999999 });
+    fireEvent(container.querySelector('.dropTarget'), event);
+
+    expect(container.querySelector('.drop-target').textContent).toEqual('p1');
   });
 });

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -236,815 +236,827 @@ describe('Tree Draggable', () => {
     (['ltr', 'rtl'] as const).forEach(dir => {
       const base = dir === 'ltr' ? 1 : -1;
 
-      it('not allow cross level dnd on expanded nodes', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable onDrop={onDrop} direction={dir} expandedKeys={['0-0', '0-1', '0-1-0']}>
-            <TreeNode key="0-0">
-              <TreeNode key="0-0-0" className="dropTarget1">
-                <TreeNode key="0-0-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-1">
-              <TreeNode key="0-1-0" className="dropTarget2">
-                <TreeNode key="0-1-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-2" className="dragTarget" />
-          </Tree>,
-        );
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireEvent.drop(container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'));
-
-        // insert after 0-0, since 0-0-0 is not expanded
-        expect(onDrop.mock.calls[0][0].node.key).toEqual('0-0');
-        expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireEvent.drop(container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'));
-
-        // insert into 0-1-0, since it is expanded, do not allow cross level dnd
-        expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0');
-        expect(onDrop.mock.calls[1][0].dropPosition).toEqual(0);
-      });
-
-      it('allowDrop all nodes', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-1">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" className="dropTarget" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-2" />
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-
-        expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
-        // (in ltr) drag from right to left, should be insert after, so drop position is 1
-        expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-
-        expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[1][0].dropPosition).toEqual(1);
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[2][0].dropPosition).toEqual(0);
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[2][0].dropPosition).toEqual(0);
-      });
-
-      it('allowDrop no node', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} allowDrop={() => false} direction={dir}>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-1">
-              <TreeNode key="0-1-0" className="dropTargetParent">
-                <TreeNode key="0-1-0-0" className="dropTarget" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-2" />
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(
-          container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
-        );
-        // not allow any dropPosition except 0 on expanded node
-        expect(onDrop).not.toHaveBeenCalled();
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
-
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
-      });
-
-      it('drop to top half of first node', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-1" className="dropTarget">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 0,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: -1000,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1');
-        expect(onDrop.mock.calls[0][0].dropPosition).toEqual(-1);
-      });
-
-      it('can drop on its direct parent', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-1" className="dropTarget">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireEvent.drop(
-          container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
-        );
-        expect(onDrop).toHaveBeenCalled();
-      });
-
-      it('cover window dragend & componentWillUnmount', () => {
-        const { container, unmount } = render(
-          <Tree draggable defaultExpandAll direction={dir}>
-            <TreeNode key="0-1" className="dropTarget">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        window.dispatchEvent(new Event('dragend'));
-        unmount();
-      });
-
-      it('dragover first half of non-first child', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-              <TreeNode key="0-0-1" />
-              <TreeNode key="0-0-2" className="dropTarget" />
-            </TreeNode>
-          </Tree>,
-        );
-        // wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart', {
-        //   clientX: base * 500,
-        //   clientY: 500,
-        // });
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragEnter', {
-        //   clientX: base * 500,
-        //   clientY: 1,
-        // });
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 500,
-            clientY: 1,
-          },
-        );
-        // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragOver', {
-        //   clientX: base * 500,
-        //   clientY: 1,
-        // });
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 500,
-            clientY: 1,
-          },
-        );
-        // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('drop');
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[0][0].node.key).toEqual('0-0-1');
-        expect(onDrop.mock.calls[0][0].dropPosition).toEqual(2);
-      });
-
-      it('dragover self', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-1" className="dropTarget">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-0" className="dragTargetParent">
-              <TreeNode key="0-0-0" className="dragTarget">
-                <TreeNode key="0-0-0-0" className="dragTargetChild" />
-              </TreeNode>
-            </TreeNode>
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 500,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
-      });
-
-      it('not allowDrop on node which has children', () => {
-        const onDrop = jest.fn();
-        const allowDrop = ({ dropNode, dropPosition }) => {
-          if (!dropNode.children) {
-            if (dropPosition === 0) return false;
-          }
-          return true;
-        };
-        const { container } = render(
-          <Tree draggable defaultExpandAll allowDrop={allowDrop} onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-0" className="dragTarget">
-              <TreeNode key="0-0-0" className="dragTargetChild" />
-            </TreeNode>
-            <TreeNode key="0-1">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" className="dropTarget" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-2" />
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
-        // (in ltr) drag from right to left, should be insert after, so drop position is 1
-        expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 500,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[1][0].dropPosition).toEqual(1);
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 550,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[2][0].dropPosition).toEqual(1);
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 600,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
-        expect(onDrop.mock.calls[2][0].dropPosition).toEqual(1);
-      });
-
-      it('allowDrop should pass dragNode and dropNode', () => {
-        const onDrop = jest.fn();
-        const allowDrop = jest.fn();
-        const { container } = render(
-          <Tree draggable defaultExpandAll allowDrop={allowDrop} onDrop={onDrop} direction={dir}>
-            <TreeNode key="0-0" className="dragTarget">
-              <TreeNode key="0-0-0" className="dragTargetChild" />
-            </TreeNode>
-            <TreeNode key="0-1">
-              <TreeNode key="0-1-0">
-                <TreeNode key="0-1-0-0" className="dropTarget" />
-              </TreeNode>
-            </TreeNode>
-            <TreeNode key="0-2" />
-          </Tree>,
-        );
-        fireDragEvent(
-          container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
-          'dragStart',
-          {
-            clientX: base * 500,
-            clientY: 500,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragEnter',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireDragEvent(
-          container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
-          'dragOver',
-          {
-            clientX: base * 400,
-            clientY: 600,
-          },
-        );
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(allowDrop.mock.calls[0][0].dragNode.key).toEqual('0-0');
-        expect(allowDrop.mock.calls[0][0].dropNode.key).toEqual('0-1-0-0');
-      });
-
-      it('not allow dragging elements outside into tree', () => {
-        const onDrop = jest.fn();
-        const { container } = render(
-          <div>
-            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+      describe(dir, () => {
+        it('not allow cross level dnd on expanded nodes', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable onDrop={onDrop} direction={dir} expandedKeys={['0-0', '0-1', '0-1-0']}>
               <TreeNode key="0-0">
-                <TreeNode key="0-0-0" className="dropTarget" />
+                <TreeNode key="0-0-0" className="dropTarget1">
+                  <TreeNode key="0-0-0-0" />
+                </TreeNode>
               </TreeNode>
-            </Tree>
-            <div className="dragTarget">Element outside</div>
-          </div>,
-        );
-        fireEvent.dragStart(container.querySelector('.dragTarget'));
-        fireEvent.dragEnter(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        fireEvent.dragOver(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
-        expect(onDrop).not.toHaveBeenCalled();
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0" className="dropTarget2">
+                  <TreeNode key="0-1-0-0" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" className="dragTarget" />
+            </Tree>,
+          );
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireEvent.drop(container.querySelector('.dropTarget1 > .rc-tree-node-content-wrapper'));
+
+          // insert after 0-0, since 0-0-0 is not expanded
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-0');
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireEvent.drop(container.querySelector('.dropTarget2 > .rc-tree-node-content-wrapper'));
+
+          // insert into 0-1-0, since it is expanded, do not allow cross level dnd
+          expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0');
+          expect(onDrop.mock.calls[1][0].dropPosition).toEqual(0);
+        });
+
+        it('allowDrop all nodes', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" className="dropTarget" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" />
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 400,
+              clientY: 500,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
+          // (in ltr) drag from right to left, should be insert after, so drop position is 1
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+
+          expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[1][0].dropPosition).toEqual(1);
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[2][0].dropPosition).toEqual(0);
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[2][0].dropPosition).toEqual(0);
+        });
+
+        it('allowDrop no node', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree
+              draggable
+              defaultExpandAll
+              onDrop={onDrop}
+              allowDrop={() => false}
+              direction={dir}
+            >
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0" className="dropTargetParent">
+                  <TreeNode key="0-1-0-0" className="dropTarget" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" />
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(
+            container.querySelector('.dropTargetParent > .rc-tree-node-content-wrapper'),
+          );
+          // not allow any dropPosition except 0 on expanded node
+          expect(onDrop).not.toHaveBeenCalled();
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+        });
+
+        it('drop to top half of first node', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-1" className="dropTarget">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 0,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: -1000,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1');
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(-1);
+        });
+
+        it('can drop on its direct parent', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-1" className="dropTarget">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireEvent.drop(
+            container.querySelector('.dragTargetParent > .rc-tree-node-content-wrapper'),
+          );
+          expect(onDrop).toHaveBeenCalled();
+        });
+
+        it('cover window dragend & componentWillUnmount', () => {
+          const { container, unmount } = render(
+            <Tree draggable defaultExpandAll direction={dir}>
+              <TreeNode key="0-1" className="dropTarget">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          window.dispatchEvent(new Event('dragend'));
+          unmount();
+        });
+
+        it('dragover first half of non-first child', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+                <TreeNode key="0-0-1" />
+                <TreeNode key="0-0-2" className="dropTarget" />
+              </TreeNode>
+            </Tree>,
+          );
+          // wrapper.find('.dragTarget > .rc-tree-node-content-wrapper').simulate('dragStart', {
+          //   clientX: base * 500,
+          //   clientY: 500,
+          // });
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragEnter', {
+          //   clientX: base * 500,
+          //   clientY: 1,
+          // });
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 500,
+              clientY: 1,
+            },
+          );
+          // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('dragOver', {
+          //   clientX: base * 500,
+          //   clientY: 1,
+          // });
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 500,
+              clientY: 1,
+            },
+          );
+          // wrapper.find('.dropTarget > .rc-tree-node-content-wrapper').simulate('drop');
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-0-1');
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(2);
+        });
+
+        it('dragover self', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-1" className="dropTarget">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-0" className="dragTargetParent">
+                <TreeNode key="0-0-0" className="dragTarget">
+                  <TreeNode key="0-0-0-0" className="dragTargetChild" />
+                </TreeNode>
+              </TreeNode>
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 500,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+        });
+
+        it('not allowDrop on node which has children', () => {
+          const onDrop = jest.fn();
+          const allowDrop = ({ dropNode, dropPosition }) => {
+            if (!dropNode.children) {
+              if (dropPosition === 0) return false;
+            }
+            return true;
+          };
+          const { container } = render(
+            <Tree draggable defaultExpandAll allowDrop={allowDrop} onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-0" className="dragTarget">
+                <TreeNode key="0-0-0" className="dragTargetChild" />
+              </TreeNode>
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" className="dropTarget" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" />
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 400,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[0][0].node.key).toEqual('0-1-0-0');
+          // (in ltr) drag from right to left, should be insert after, so drop position is 1
+          expect(onDrop.mock.calls[0][0].dropPosition).toEqual(1);
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 500,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[1][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[1][0].dropPosition).toEqual(1);
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 550,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[2][0].dropPosition).toEqual(1);
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 500,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 600,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop.mock.calls[2][0].node.key).toEqual('0-1-0-0');
+          expect(onDrop.mock.calls[2][0].dropPosition).toEqual(1);
+        });
+
+        it('allowDrop should pass dragNode and dropNode', () => {
+          const onDrop = jest.fn();
+          const allowDrop = jest.fn();
+          const { container } = render(
+            <Tree draggable defaultExpandAll allowDrop={allowDrop} onDrop={onDrop} direction={dir}>
+              <TreeNode key="0-0" className="dragTarget">
+                <TreeNode key="0-0-0" className="dragTargetChild" />
+              </TreeNode>
+              <TreeNode key="0-1">
+                <TreeNode key="0-1-0">
+                  <TreeNode key="0-1-0-0" className="dropTarget" />
+                </TreeNode>
+              </TreeNode>
+              <TreeNode key="0-2" />
+            </Tree>,
+          );
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            {
+              clientX: base * 400,
+              clientY: 500,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            {
+              clientX: base * 400,
+              clientY: 600,
+            },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(allowDrop.mock.calls[0][0].dragNode.key).toEqual('0-0');
+          expect(allowDrop.mock.calls[0][0].dropNode.key).toEqual('0-1-0-0');
+        });
+
+        it('not allow dragging elements outside into tree', () => {
+          const onDrop = jest.fn();
+          const { container } = render(
+            <div>
+              <Tree draggable defaultExpandAll onDrop={onDrop} direction={dir}>
+                <TreeNode key="0-0">
+                  <TreeNode key="0-0-0" className="dropTarget" />
+                </TreeNode>
+              </Tree>
+              <div className="dragTarget">Element outside</div>
+            </div>,
+          );
+          fireEvent.dragStart(container.querySelector('.dragTarget'));
+          fireEvent.dragEnter(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+          );
+          fireEvent.dragOver(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+          expect(onDrop).not.toHaveBeenCalled();
+        });
       });
     });
   });
@@ -1178,9 +1190,9 @@ describe('Tree Draggable', () => {
     fireEvent.dragStart(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
 
     // Drag over
-    const event = createEvent.dragOver(container.querySelector('.dropTarget'));
-    Object.defineProperty(event, 'clientX', { value: -9999999999 });
-    fireEvent(container.querySelector('.dropTarget'), event);
+    fireDragEvent(container.querySelector('.dropTarget'), 'dragOver', {
+      clientX: -9999999,
+    });
 
     expect(container.querySelector('.drop-target').textContent).toEqual('p1');
   });

--- a/tests/TreeProps.spec.tsx
+++ b/tests/TreeProps.spec.tsx
@@ -419,23 +419,15 @@ describe('Tree Props', () => {
   // autoExpandParent - is already full test in Tree.spec.js
 
   it('defaultExpandAll', () => {
-    const onExpand = jest.fn();
-
     const { container } = render(
-      <Tree defaultExpandAll onExpand={onExpand}>
+      <Tree defaultExpandAll>
         <TreeNode key="0-0" title="parent">
           <TreeNode key="0-0-0" title="child" />
         </TreeNode>
       </Tree>,
     );
 
-    console.log(container.innerHTML);
-
     expect(container.firstChild).toMatchSnapshot();
-
-    // Click to get new expandedKeys
-    fireEvent.click(container.querySelector('.rc-tree-switcher_open'));
-    expect(onExpand).toHaveBeenCalledWith([], expect.anything());
   });
 
   // defaultCheckedKeys - is already full test in Tree.spec.js

--- a/tests/TreeProps.spec.tsx
+++ b/tests/TreeProps.spec.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable no-undef, react/no-multi-comp */
-import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { resetWarned } from 'rc-util/lib/warning';
-import Tree, { TreeNode, FieldDataNode } from '../src';
+import React from 'react';
+import Tree, { FieldDataNode, TreeNode } from '../src';
 import { objectMatcher, spyConsole, spyError } from './util';
 
 /**
@@ -418,17 +418,24 @@ describe('Tree Props', () => {
   // draggable - is already full test in Tree.spec.js
   // autoExpandParent - is already full test in Tree.spec.js
 
-  // defaultExpandAll
   it('defaultExpandAll', () => {
+    const onExpand = jest.fn();
+
     const { container } = render(
-      <Tree defaultExpandAll>
-        <TreeNode key="0-0">
-          <TreeNode key="0-0-0" />
+      <Tree defaultExpandAll onExpand={onExpand}>
+        <TreeNode key="0-0" title="parent">
+          <TreeNode key="0-0-0" title="child" />
         </TreeNode>
       </Tree>,
     );
 
+    console.log(container.innerHTML);
+
     expect(container.firstChild).toMatchSnapshot();
+
+    // Click to get new expandedKeys
+    fireEvent.click(container.querySelector('.rc-tree-switcher_open'));
+    expect(onExpand).toHaveBeenCalledWith([], expect.anything());
   });
 
   // defaultCheckedKeys - is already full test in Tree.spec.js

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -853,7 +853,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
-              title="---"
+              title="parent"
             >
               <span
                 class="rc-tree-iconEle rc-tree-icon__open"
@@ -861,7 +861,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
               <span
                 class="rc-tree-title"
               >
-                ---
+                parent
               </span>
             </span>
           </div>
@@ -883,7 +883,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
-              title="---"
+              title="child"
             >
               <span
                 class="rc-tree-iconEle rc-tree-icon__docu"
@@ -891,7 +891,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
               <span
                 class="rc-tree-title"
               >
-                ---
+                child
               </span>
             </span>
           </div>


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/47180

测试用例有几个 magic number 看了一下，应该也是因为这个递归计算问题导致的。