### PR TITLE
enhance: perf of babel

### DIFF
--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -148,18 +148,20 @@ export function flattenTreeData<TreeDataType extends BasicDataNode = DataNode>(
       }
 
       // Add FlattenDataNode into list
-      const flattenNode: FlattenNode<TreeDataType> = {
-        ...omit(treeNode, [...fieldTitles, fieldKey, fieldChildren] as any),
-        title: mergedTitle,
-        key: mergedKey,
-        parent,
-        pos,
-        children: null,
-        data: treeNode,
-        isStart: [...(parent ? parent.isStart : []), index === 0],
-        isEnd: [...(parent ? parent.isEnd : []), index === list.length - 1],
-      };
-
+      // We use `Object.assign` here to save perf since babel's `objectSpread` has perf issue
+      const flattenNode: FlattenNode<TreeDataType> = Object.assign(
+        omit(treeNode, [...fieldTitles, fieldKey, fieldChildren] as any),
+        {
+          title: mergedTitle,
+          key: mergedKey,
+          parent,
+          pos,
+          children: null,
+          data: treeNode,
+          isStart: [...(parent ? parent.isStart : []), index === 0],
+          isEnd: [...(parent ? parent.isEnd : []), index === list.length - 1],
+        },
+      );
       flattenList.push(flattenNode);
 
       // Loop treeNode children


### PR DESCRIPTION
babel 会对解构进行转换，导致额外的对象创建和属性遍历。但是对于简单对象而言，这是没有必要的。直接使用 `Object.assign` 对 `omit` 后的对象进行填充以减少额外的对象创建数量，并且跳过一些检查逻辑以节约性能：

### Before

<img width="648" alt="截屏2024-06-12 14 01 48" src="https://github.com/react-component/tree/assets/5378891/4aa28498-bc46-4b33-8a35-0a3b054c8d80">

### After

<img width="495" alt="截屏2024-06-12 14 01 05" src="https://github.com/react-component/tree/assets/5378891/ba3a61e5-712a-4aa2-a32e-11ce5283723c">
