### PR TITLE
perf: enhance virtual Tree perf

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -5,6 +5,7 @@
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import VirtualList, { ListRef } from 'rc-virtual-list';
 import * as React from 'react';
+import MotionTreeNode from './MotionTreeNode';
 import {
   BasicDataNode,
   DataEntity,
@@ -14,7 +15,6 @@ import {
   KeyEntities,
   ScrollTo,
 } from './interface';
-import MotionTreeNode from './MotionTreeNode';
 import { findExpandedKeys, getExpandRange } from './utils/diffUtil';
 import { getKey, getTreeNodeProps } from './utils/treeUtil';
 
@@ -326,12 +326,12 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         itemHeight={itemHeight}
         prefixCls={`${prefixCls}-list`}
         ref={listRef}
-        onVisibleChange={(originList, fullList) => {
-          const originSet = new Set(originList);
-          const restList = fullList.filter(item => !originSet.has(item));
-
-          // Motion node is not render. Skip motion
-          if (restList.some(item => itemKey(item) === MOTION_KEY)) {
+        onVisibleChange={originList => {
+          // The best match is using `fullList` - `originList` = `restList`
+          // and check the `restList` to see if has the MOTION_KEY node
+          // but this will cause performance issue for long list compare
+          // we just check `originList` and repeat trigger `onMotionEnd`
+          if (originList.every(item => itemKey(item) !== MOTION_KEY)) {
             onMotionEnd();
           }
         }}

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -398,10 +398,16 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
 
-      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => {
+      // Only take the key who has the children to enhance the performance
+      const nextExpandedKeys: React.Key[] = [];
+      Object.keys(cloneKeyEntities).forEach(key => {
         const entity = cloneKeyEntities[key];
-        return entity.children && entity.children.length ? entity.key : null;
+        if (entity.children && entity.children.length) {
+          nextExpandedKeys.push(key);
+        }
       });
+
+      newState.expandedKeys = nextExpandedKeys;
     } else if (!prevProps && props.defaultExpandedKeys) {
       newState.expandedKeys =
         props.autoExpandParent || props.defaultExpandParent

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -403,7 +403,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       Object.keys(cloneKeyEntities).forEach(key => {
         const entity = cloneKeyEntities[key];
         if (entity.children && entity.children.length) {
-          nextExpandedKeys.push(key);
+          nextExpandedKeys.push(entity.key);
         }
       });
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -397,7 +397,11 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
-      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => cloneKeyEntities[key].key);
+
+      newState.expandedKeys = Object.keys(cloneKeyEntities).map(key => {
+        const entity = cloneKeyEntities[key];
+        return entity.children && entity.children.length ? entity.key : null;
+      });
     } else if (!prevProps && props.defaultExpandedKeys) {
       newState.expandedKeys =
         props.autoExpandParent || props.defaultExpandParent

--- a/tests/Accessibility.spec.tsx
+++ b/tests/Accessibility.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp */
-import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
 import KeyCode from 'rc-util/lib/KeyCode';
-import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
 import Tree, { FieldDataNode } from '../src';
 import { spyConsole } from './util';
 
@@ -34,7 +34,7 @@ describe('Tree Accessibility', () => {
           onBlur={onBlur}
           onKeyDown={onKeyDown}
           onActiveChange={onActiveChange}
-          defaultExpandAll
+          defaultExpandedKeys={['parent', 'child 1', 'child 2']}
           treeData={[{ key: 'parent', children: [{ key: 'child 1' }, { key: 'child 2' }] }]}
         />,
       );

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -371,7 +371,7 @@ describe('Tree Basic', () => {
     // https://github.com/react-component/tree/issues/117
     it('check works correctly after dragging children under another node', () => {
       const renderTree = (children: React.ReactNode) => (
-        <Tree defaultExpandAll checkable>
+        <Tree defaultExpandedKeys={['0-0', '0-0-1']} checkable>
           {children}
         </Tree>
       );

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -68,7 +68,7 @@ describe('Tree Draggable', () => {
     });
     const event = onDragEnter.mock.calls[0][0];
     expect(event.node.key).toEqual('0-0-0-1');
-    expect(event.expandedKeys).toEqual(['0-0', '0-0-0-1']);
+    expect(event.expandedKeys).toEqual(['0-0']);
     expect(onDragEnter).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -2,6 +2,7 @@
 react/no-unused-state, react/prop-types, no-return-assign */
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
+import React from 'react';
 import Tree, { FieldDataNode, TreeNode, TreeProps } from '../src';
 import { spyConsole } from './util';
 

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -69,7 +69,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -102,7 +102,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -361,7 +361,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -387,7 +387,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -458,7 +458,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -510,7 +510,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -540,7 +540,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -677,7 +677,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -713,7 +713,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -749,7 +749,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -96,7 +96,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -129,7 +129,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -159,7 +159,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -230,7 +230,7 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -305,7 +305,7 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -380,7 +380,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -507,7 +507,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-grabbed="false"
             aria-label="0-0-0-0"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -541,7 +541,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-grabbed="false"
             aria-label="0-0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -572,7 +572,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-grabbed="false"
             aria-label="0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -701,7 +701,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-0-0"
             draggable="false"
           >
@@ -735,7 +735,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-1"
             draggable="false"
           >
@@ -766,7 +766,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-1"
             draggable="false"
           >
@@ -1060,7 +1060,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1072,14 +1072,14 @@ exports[`TreeNode Props isLeaf 3`] = `
               />
             </span>
             <span
-              class="rc-tree-switcher rc-tree-switcher_open"
+              class="rc-tree-switcher rc-tree-switcher_close"
             />
             <span
-              class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
+              class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-close"
               title="---"
             >
               <span
-                class="rc-tree-iconEle rc-tree-icon__open"
+                class="rc-tree-iconEle rc-tree-icon__close"
               />
               <span
                 class="rc-tree-title"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -361,7 +361,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -417,7 +417,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -447,7 +447,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -522,7 +522,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -552,7 +552,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -608,7 +608,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -642,7 +642,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -676,7 +676,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -867,7 +867,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -943,7 +943,7 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1015,7 +1015,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1116,7 +1116,7 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1224,7 +1224,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1331,7 +1331,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -1530,7 +1530,7 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -2321,7 +2321,7 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -2373,7 +2373,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -2433,7 +2433,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
           >
             <span
@@ -2466,7 +2466,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -2499,7 +2499,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span
@@ -2574,7 +2574,7 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-grabbed="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
           >
             <span

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "moduleResolution": "node",
     "baseUrl": "./",
-    "jsx": "preserve",
+    "jsx": "react",
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -23,6 +23,7 @@
     ".dumirc.ts",
     "./src/**/*.ts",
     "./src/**/*.tsx",
-    "./docs/**/*.tsx"
+    "./docs/**/*.tsx",
+    "./tests/**/*.tsx",
   ]
 }


### PR DESCRIPTION
### 对比

```tsx
<Tree defaultExpandAll data={100w Data} />
```

**Scroll**: ~400ms ->  ~50ms ⬇️
**Expand**: ~200ms -> ~20ms ⬇️

### 优化

* `onMotionEnd`: 在滚动时，会触发 `onVisibleChange` 事件来检查当前的滚动节点里包含不包含动画节点。如果动画节点被移出屏幕外，则直接触发 `onMotionEnd` 事件（如果不触发就会因为节点被删除而永远卡在缩放动画阶段）。原代码实现逻辑为 `所有节点` - `当前展示节点` 得到 `不可见节点`，然后判断一下 `不可见节点` 是否存在动画节点。这里直接改成在 `当前展示节点` 里检查是否有动画节点，没有就触发 `onMotionEnd` 事件。虽然这会反复触发事件，但是对于 Tree 而言，这个状态变化是原子的。相对安全。
* `defaultExpandAll`: 在收缩时会通过 `expandedKeys` 来计算出需要交由虚拟滚动的 `flattenData`，当设置 `defaultExpandAll` 时，会导致 `expandedKeys` 被塞入所有节点的 `keys`。因而在 diff 计算时相当于遍历了所有节点导致卡顿。而对于子节点，其实不需要将其 `key` 参与计算，因而调整 `defaultExpandAll` 逻辑，仅统计有 `children` 的节点的 `key`。由于这是个 break change（相对可控），需要发个 minor 版本。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进了 `NodeList` 组件的可见性变化处理，提高了性能。
	- 优化了 `Tree` 组件的默认展开逻辑，仅展开具有子节点的项。

- **测试**
	- 更新了测试文件中的 `Tree` 组件属性，改为使用 `defaultExpandedKeys`，以更精确地控制树的初始状态。
	- 修改了 `TreeDraggable` 组件的测试预期值，以反映更准确的拖放操作结果。

- **配置**
	- 更新了 TypeScript 配置，改进了 JSX 处理和测试文件的编译范围。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->