### PR TITLE
refactor: Replace the "in" operator with hasOwnProperty.

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -350,7 +350,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     };
 
     function needSync(name: string) {
-      return (!prevProps && name in props) || (prevProps && prevProps[name] !== props[name]);
+      return (
+        (!prevProps && props.hasOwnProperty(name)) || (prevProps && prevProps[name] !== props[name])
+      );
     }
 
     // ================== Tree Node ==================
@@ -579,7 +581,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           newExpandedKeys = arrAdd(expandedKeys, node.props.eventKey);
         }
 
-        if (!('expandedKeys' in this.props)) {
+        if (!this.props.hasOwnProperty('expandedKeys')) {
           this.setExpandedKeys(newExpandedKeys);
         }
 
@@ -1336,7 +1338,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       const newState = {};
 
       Object.keys(state).forEach(name => {
-        if (name in this.props) {
+        if (this.props.hasOwnProperty(name)) {
           allPassed = false;
           return;
         }


### PR DESCRIPTION
Replace the "in" operator in Tree.tsx to avoid unnecessary prototype chain traversal behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了树形组件的属性同步机制，增强了对属性变化的响应能力。
	- 优化了树节点的展开状态管理，确保在拖放操作中正确处理展开键。
- **修复**
	- 调整了拖放功能的条件检查，提升了组件在拖放过程中的表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->