### PR TITLE
feat: improve a11y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .storybook
+.vscode
 *.iml
 *.log
 .doc/

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -284,7 +284,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         </span>
       )}
 
-      <div>
+      <div aria-hidden>
         <input
           style={HIDDEN_STYLE}
           disabled={focusable === false || disabled}
@@ -293,8 +293,8 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
           onFocus={onFocus}
           onBlur={onBlur}
           value=""
+          role="presentation"
           onChange={noop}
-          aria-label="for screen reader"
         />
       </div>
 

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -284,7 +284,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         </span>
       )}
 
-      <div aria-hidden>
+      <div>
         <input
           style={HIDDEN_STYLE}
           disabled={focusable === false || disabled}
@@ -293,8 +293,8 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
           onFocus={onFocus}
           onBlur={onBlur}
           value=""
-          role="presentation"
           onChange={noop}
+          aria-label="for screen reader"
         />
       </div>
 
@@ -326,6 +326,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         itemHeight={itemHeight}
         prefixCls={`${prefixCls}-list`}
         ref={listRef}
+        role="tree"
         onVisibleChange={originList => {
           // The best match is using `fullList` - `originList` = `restList`
           // and check the `restList` to see if has the MOTION_KEY node

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1468,7 +1468,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
         }}
       >
         <div
-          role="tree"
           className={classNames(prefixCls, className, rootClassName, {
             [`${prefixCls}-show-line`]: showLine,
             [`${prefixCls}-focused`]: focused,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -550,7 +550,6 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
         ref={domRef}
         role="treeitem"
         aria-expanded={isLeaf ? undefined : expanded}
-        aria-selected={selected ? 'true' : undefined}
         className={classNames(className, `${prefixCls}-treenode`, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -536,7 +536,9 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     } = this.props;
     const disabled = this.isDisabled();
     const dataOrAriaAttributeProps = pickAttrs(otherProps, { aria: true, data: true });
-    const { level } = getEntity(keyEntities, eventKey) || {};
+    const { level, parent } = getEntity(keyEntities, eventKey) || {};
+    const siblings = parent?.children || [];
+    const posInSet = siblings.findIndex(node => node.key === eventKey);
     const isEndNode = isEnd[isEnd.length - 1];
 
     const mergedDraggable = this.isDraggable();
@@ -549,6 +551,10 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
       <div
         ref={domRef}
         role="treeitem"
+        aria-expanded={isLeaf ? undefined : expanded}
+        aria-level={level}
+        aria-setsize={siblings.length}
+        aria-posinset={posInSet}
         className={classNames(className, `${prefixCls}-treenode`, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -538,7 +538,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     const dataOrAriaAttributeProps = pickAttrs(otherProps, { aria: true, data: true });
     const { level, parent } = getEntity(keyEntities, eventKey) || {};
     const siblings = parent?.children || [];
-    const posInSet = siblings.findIndex(node => node.key === eventKey);
+    const posInSet = siblings.findIndex(node => node.key === eventKey) + 1;
     const isEndNode = isEnd[isEnd.length - 1];
 
     const mergedDraggable = this.isDraggable();

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -374,6 +374,9 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
           (disabled || disableCheckbox) && `${prefixCls}-checkbox-disabled`,
         )}
         onClick={this.onCheck}
+        role="checkbox"
+        aria-checked={halfChecked ? 'mixed' : checked}
+        aria-disabled={disabled || disableCheckbox}
       >
         {$custom}
       </span>
@@ -545,6 +548,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     return (
       <div
         ref={domRef}
+        role="treeitem"
         className={classNames(className, `${prefixCls}-treenode`, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
@@ -567,7 +571,6 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
         style={style}
         // Draggable config
         draggable={draggableWithoutDisabled}
-        aria-grabbed={dragging}
         onDragStart={draggableWithoutDisabled ? this.onDragStart : undefined}
         // Drop config
         onDragEnter={mergedDraggable ? this.onDragEnter : undefined}

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -353,7 +353,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
   // ====================== Render: Checkbox ======================
   // Checkbox
   renderCheckbox = () => {
-    const { checked, halfChecked, disableCheckbox } = this.props;
+    const { checked, halfChecked, disableCheckbox, title } = this.props;
     const {
       context: { prefixCls },
     } = this.props;
@@ -377,6 +377,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
         role="checkbox"
         aria-checked={halfChecked ? 'mixed' : checked}
         aria-disabled={disabled || disableCheckbox}
+        aria-label={`Select ${typeof title === 'string' ? title : 'tree node'}`}
       >
         {$custom}
       </span>

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -536,9 +536,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     } = this.props;
     const disabled = this.isDisabled();
     const dataOrAriaAttributeProps = pickAttrs(otherProps, { aria: true, data: true });
-    const { level, parent } = getEntity(keyEntities, eventKey) || {};
-    const siblings = parent?.children || [];
-    const posInSet = siblings.findIndex(node => node.key === eventKey) + 1;
+    const { level } = getEntity(keyEntities, eventKey) || {};
     const isEndNode = isEnd[isEnd.length - 1];
 
     const mergedDraggable = this.isDraggable();
@@ -552,9 +550,6 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
         ref={domRef}
         role="treeitem"
         aria-expanded={isLeaf ? undefined : expanded}
-        aria-level={level}
-        aria-setsize={siblings.length}
-        aria-posinset={posInSet}
         className={classNames(className, `${prefixCls}-treenode`, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -550,6 +550,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
         ref={domRef}
         role="treeitem"
         aria-expanded={isLeaf ? undefined : expanded}
+        aria-selected={selected ? 'true' : undefined}
         className={classNames(className, `${prefixCls}-treenode`, {
           [`${prefixCls}-treenode-disabled`]: disabled,
           [`${prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -78,7 +78,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
             draggable="false"
@@ -118,7 +118,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -204,7 +204,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
@@ -239,7 +239,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
@@ -325,7 +325,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
@@ -407,7 +407,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -437,7 +437,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -514,7 +514,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -544,7 +544,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -574,7 +574,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -608,7 +608,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -689,7 +689,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -724,7 +724,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
@@ -764,7 +764,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -806,7 +806,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -848,7 +848,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -935,7 +935,7 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1013,7 +1013,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1043,7 +1043,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1073,7 +1073,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1103,7 +1103,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1133,7 +1133,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1163,7 +1163,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1193,7 +1193,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1223,7 +1223,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -1253,7 +1253,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -5,9 +5,11 @@ exports[`Tree Basic check basic render 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -39,9 +41,9 @@ exports[`Tree Basic check basic render 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -51,7 +53,9 @@ exports[`Tree Basic check basic render 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -68,9 +72,9 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -84,7 +88,10 @@ exports[`Tree Basic check basic render 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
+              aria-disabled="true"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -101,9 +108,9 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -117,7 +124,9 @@ exports[`Tree Basic check basic render 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -145,9 +154,11 @@ exports[`Tree Basic check check after data ready works 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -179,9 +190,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -191,7 +202,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="true"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -208,9 +221,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -224,7 +237,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="true"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -252,9 +267,11 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -286,9 +303,9 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -298,7 +315,9 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="true"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -326,9 +345,11 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -360,9 +381,9 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -386,9 +407,9 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -423,9 +444,11 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -457,9 +480,9 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -483,9 +506,9 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -509,9 +532,9 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -539,9 +562,9 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -580,9 +603,11 @@ exports[`Tree Basic renders correctly 1`] = `
   class="rc-tree forTest rc-tree-show-line"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -614,9 +639,9 @@ exports[`Tree Basic renders correctly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -626,7 +651,9 @@ exports[`Tree Basic renders correctly 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -643,9 +670,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -659,7 +686,10 @@ exports[`Tree Basic renders correctly 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
+              aria-disabled="true"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -676,9 +706,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -695,7 +725,9 @@ exports[`Tree Basic renders correctly 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -712,9 +744,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -731,7 +763,9 @@ exports[`Tree Basic renders correctly 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -748,9 +782,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -764,7 +798,10 @@ exports[`Tree Basic renders correctly 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
+              aria-disabled="true"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -792,9 +829,11 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -826,9 +865,9 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -864,9 +903,11 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
   role="tree"
   style="background-color: cyan;"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -898,9 +939,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -924,9 +965,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -950,9 +991,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -976,9 +1017,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1002,9 +1043,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1028,9 +1069,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1054,9 +1095,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1080,9 +1121,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1106,9 +1147,9 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -41,6 +41,10 @@ exports[`Tree Basic check basic render 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -72,6 +76,10 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -108,6 +116,10 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -190,6 +202,10 @@ exports[`Tree Basic check check after data ready works 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -221,6 +237,10 @@ exports[`Tree Basic check check after data ready works 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -303,6 +323,10 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -381,6 +405,10 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -407,6 +435,10 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -480,6 +512,10 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -506,6 +542,10 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -532,6 +572,10 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -562,6 +606,10 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -639,6 +687,10 @@ exports[`Tree Basic renders correctly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -670,6 +722,10 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -706,6 +762,10 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -744,6 +804,10 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -782,6 +846,10 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -865,6 +933,10 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -939,6 +1011,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -965,6 +1041,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -991,6 +1071,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1017,6 +1101,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1043,6 +1131,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1069,6 +1161,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1095,6 +1191,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1121,6 +1221,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1147,6 +1251,10 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -3,13 +3,10 @@
 exports[`Tree Basic check basic render 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -30,6 +27,7 @@ exports[`Tree Basic check basic render 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -155,13 +153,10 @@ exports[`Tree Basic check basic render 1`] = `
 exports[`Tree Basic check check after data ready works 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -182,6 +177,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -270,13 +266,10 @@ exports[`Tree Basic check check after data ready works 1`] = `
 exports[`Tree Basic check check update when Tree trigger componentWillReceiveProps 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -297,6 +290,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -349,13 +343,10 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
 exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -376,6 +367,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -450,13 +442,10 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
 exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -477,6 +466,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -613,13 +603,10 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
 exports[`Tree Basic renders correctly 1`] = `
 <div
   class="rc-tree forTest rc-tree-show-line"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -640,6 +627,7 @@ exports[`Tree Basic renders correctly 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -844,13 +832,10 @@ exports[`Tree Basic renders correctly 1`] = `
 exports[`Tree Basic renders opaque children correctly 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -871,6 +856,7 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -918,14 +904,11 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
 exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
 <div
   class="rc-tree root-tree"
-  role="tree"
   style="background-color: cyan;"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -946,6 +929,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -42,9 +42,6 @@ exports[`Tree Basic check basic render 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -77,9 +74,6 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -117,9 +111,6 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -203,9 +194,6 @@ exports[`Tree Basic check check after data ready works 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -238,9 +226,6 @@ exports[`Tree Basic check check after data ready works 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -324,9 +309,6 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -406,9 +388,6 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -436,9 +415,6 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -513,9 +489,6 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -543,9 +516,6 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -573,9 +543,6 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -607,9 +574,6 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -688,9 +652,6 @@ exports[`Tree Basic renders correctly 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -723,9 +684,6 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -763,9 +721,6 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -805,9 +760,6 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -847,9 +799,6 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -934,9 +883,6 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1012,9 +958,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1042,9 +985,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1072,9 +1012,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1102,9 +1039,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1132,9 +1066,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1162,9 +1093,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1192,9 +1120,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1222,9 +1147,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1252,9 +1174,6 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -53,6 +53,7 @@ exports[`Tree Basic check basic render 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -90,6 +91,7 @@ exports[`Tree Basic check basic render 1`] = `
             <span
               aria-checked="false"
               aria-disabled="true"
+              aria-label="Select tree node"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
               role="checkbox"
             />
@@ -126,6 +128,7 @@ exports[`Tree Basic check basic render 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -203,6 +206,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
             />
             <span
               aria-checked="true"
+              aria-label="Select Light"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
               role="checkbox"
             />
@@ -239,6 +243,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
             />
             <span
               aria-checked="true"
+              aria-label="Select Bamboo"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
               role="checkbox"
             />
@@ -316,6 +321,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
             />
             <span
               aria-checked="true"
+              aria-label="Select parent 1"
               class="rc-tree-checkbox rc-tree-checkbox-checked"
               role="checkbox"
             />
@@ -653,6 +659,7 @@ exports[`Tree Basic renders correctly 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select parent 1"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -690,6 +697,7 @@ exports[`Tree Basic renders correctly 1`] = `
             <span
               aria-checked="false"
               aria-disabled="true"
+              aria-label="Select leaf 1"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
               role="checkbox"
             />
@@ -729,6 +737,7 @@ exports[`Tree Basic renders correctly 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select leaf"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -768,6 +777,7 @@ exports[`Tree Basic renders correctly 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select leaf"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -805,6 +815,7 @@ exports[`Tree Basic renders correctly 1`] = `
             <span
               aria-checked="false"
               aria-disabled="true"
+              aria-label="Select leaf 2"
               class="rc-tree-checkbox rc-tree-checkbox-disabled"
               role="checkbox"
             />

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`TreeNode Props className 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -73,7 +73,7 @@ exports[`TreeNode Props className 1`] = `
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -107,7 +107,7 @@ exports[`TreeNode Props className 1`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -144,7 +144,7 @@ exports[`TreeNode Props className 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -178,7 +178,7 @@ exports[`TreeNode Props className 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -255,7 +255,7 @@ exports[`TreeNode Props customize icon component 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -336,7 +336,7 @@ exports[`TreeNode Props customize icon element 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -417,7 +417,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -492,7 +492,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             aria-expanded="true"
             aria-label="0-0"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -523,7 +523,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             aria-expanded="true"
             aria-label="0-0-0"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -558,7 +558,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             aria-expanded="false"
             aria-label="0-0-0-0"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -596,7 +596,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             aria-expanded="false"
             aria-label="0-0-1"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -631,7 +631,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             aria-expanded="false"
             aria-label="0-1"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -708,7 +708,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
@@ -739,7 +739,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
@@ -774,7 +774,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-0-0"
@@ -812,7 +812,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-1"
@@ -847,7 +847,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-1"
@@ -924,7 +924,7 @@ exports[`TreeNode Props isLeaf 1`] = `
         >
           <div
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
@@ -950,7 +950,7 @@ exports[`TreeNode Props isLeaf 1`] = `
           </div>
           <div
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1027,7 +1027,7 @@ exports[`TreeNode Props isLeaf 2`] = `
         >
           <div
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1056,7 +1056,7 @@ exports[`TreeNode Props isLeaf 2`] = `
           </div>
           <div
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1137,7 +1137,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1167,7 +1167,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -5,9 +5,11 @@ exports[`TreeNode Props className 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -39,9 +41,9 @@ exports[`TreeNode Props className 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -65,9 +67,9 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -95,9 +97,9 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -128,9 +130,9 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -158,9 +160,9 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -195,9 +197,11 @@ exports[`TreeNode Props customize icon component 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -229,9 +233,9 @@ exports[`TreeNode Props customize icon component 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -270,9 +274,11 @@ exports[`TreeNode Props customize icon element 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -304,9 +310,9 @@ exports[`TreeNode Props customize icon element 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -345,9 +351,11 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -379,9 +387,9 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -413,9 +421,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -447,10 +457,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             aria-label="0-0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -474,10 +484,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             aria-label="0-0-0"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -505,10 +515,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             aria-label="0-0-0-0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -539,10 +549,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             aria-label="0-0-1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -570,10 +580,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             aria-label="0-1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -608,9 +618,11 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -642,10 +654,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -669,10 +681,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -700,10 +712,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-0-0"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -734,10 +746,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-1"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -765,10 +777,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-1"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -803,9 +815,11 @@ exports[`TreeNode Props isLeaf 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -837,9 +851,9 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -860,9 +874,9 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -898,9 +912,11 @@ exports[`TreeNode Props isLeaf 2`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -932,9 +948,9 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -958,9 +974,9 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -999,9 +1015,11 @@ exports[`TreeNode Props isLeaf 3`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1033,9 +1051,9 @@ exports[`TreeNode Props isLeaf 3`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1059,9 +1077,9 @@ exports[`TreeNode Props isLeaf 3`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -41,6 +41,10 @@ exports[`TreeNode Props className 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -67,6 +71,10 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -97,6 +105,10 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -130,6 +142,10 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -160,6 +176,10 @@ exports[`TreeNode Props className 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -233,6 +253,10 @@ exports[`TreeNode Props customize icon component 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -310,6 +334,10 @@ exports[`TreeNode Props customize icon element 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -387,6 +415,10 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -457,7 +489,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
             aria-label="0-0"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -484,7 +520,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="true"
             aria-label="0-0-0"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -515,7 +555,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
             aria-label="0-0-0-0"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -549,7 +593,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
             aria-label="0-0-1"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -580,7 +628,11 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
             aria-label="0-1"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -654,6 +706,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
             draggable="false"
@@ -681,6 +737,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
             draggable="false"
@@ -712,6 +772,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-0-0"
             draggable="false"
@@ -746,6 +810,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-1"
             draggable="false"
@@ -777,6 +845,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-1"
             draggable="false"
@@ -851,6 +923,9 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -874,6 +949,9 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -948,6 +1026,9 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -974,6 +1055,9 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1051,6 +1135,10 @@ exports[`TreeNode Props isLeaf 3`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1077,6 +1165,10 @@ exports[`TreeNode Props isLeaf 3`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -42,9 +42,6 @@ exports[`TreeNode Props className 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -72,9 +69,6 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -106,9 +100,6 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -143,9 +134,6 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -177,9 +165,6 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -254,9 +239,6 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -335,9 +317,6 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -416,9 +395,6 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -491,9 +467,6 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -522,9 +495,6 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0-0"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -557,9 +527,6 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-0-0"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -595,9 +562,6 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-1"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -630,9 +594,6 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-1"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -707,9 +668,6 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
             draggable="false"
@@ -738,9 +696,6 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
             draggable="false"
@@ -773,9 +728,6 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-0-0"
             draggable="false"
@@ -811,9 +763,6 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-0-1"
             draggable="false"
@@ -846,9 +795,6 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             data-test="0-1"
             draggable="false"
@@ -923,9 +869,6 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -949,9 +892,6 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1026,9 +966,6 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1055,9 +992,6 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1136,9 +1070,6 @@ exports[`TreeNode Props isLeaf 3`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1166,9 +1097,6 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -3,13 +3,10 @@
 exports[`TreeNode Props className 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -30,6 +27,7 @@ exports[`TreeNode Props className 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -200,13 +198,10 @@ exports[`TreeNode Props className 1`] = `
 exports[`TreeNode Props customize icon component 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -227,6 +222,7 @@ exports[`TreeNode Props customize icon component 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -278,13 +274,10 @@ exports[`TreeNode Props customize icon component 1`] = `
 exports[`TreeNode Props customize icon element 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -305,6 +298,7 @@ exports[`TreeNode Props customize icon element 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -356,13 +350,10 @@ exports[`TreeNode Props customize icon element 1`] = `
 exports[`TreeNode Props customize icon hide icon 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -383,6 +374,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -427,13 +419,10 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
 exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -454,6 +443,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -629,13 +619,10 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
 exports[`TreeNode Props data and aria props renders data attributes on li 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -656,6 +643,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -831,13 +819,10 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
 exports[`TreeNode Props isLeaf 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -858,6 +843,7 @@ exports[`TreeNode Props isLeaf 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -928,13 +914,10 @@ exports[`TreeNode Props isLeaf 1`] = `
 exports[`TreeNode Props isLeaf 2`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -955,6 +938,7 @@ exports[`TreeNode Props isLeaf 2`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1031,13 +1015,10 @@ exports[`TreeNode Props isLeaf 2`] = `
 exports[`TreeNode Props isLeaf 3`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1058,6 +1039,7 @@ exports[`TreeNode Props isLeaf 3`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -42,9 +42,6 @@ exports[`Tree Props checkStrictly 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -77,9 +74,6 @@ exports[`Tree Props checkStrictly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -163,9 +157,6 @@ exports[`Tree Props checkable default 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -198,9 +189,6 @@ exports[`Tree Props checkable default 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -284,9 +272,6 @@ exports[`Tree Props checkable without selectable 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -319,9 +304,6 @@ exports[`Tree Props checkable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -405,9 +387,6 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -435,9 +414,6 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -469,9 +445,6 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -503,9 +476,6 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -584,9 +554,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -618,9 +585,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -652,9 +616,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -682,9 +643,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -720,9 +678,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -758,9 +713,6 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -933,9 +885,6 @@ exports[`Tree Props defaultExpandAll 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -963,9 +912,6 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1045,9 +991,6 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1123,9 +1066,6 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1200,9 +1140,6 @@ exports[`Tree Props icon 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1234,9 +1171,6 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1319,9 +1253,6 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1354,9 +1285,6 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1440,9 +1368,6 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1475,9 +1400,6 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1561,9 +1483,6 @@ exports[`Tree Props loadData basic 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1588,9 +1507,6 @@ exports[`Tree Props loadData basic 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1666,9 +1582,6 @@ exports[`Tree Props multiple 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1696,9 +1609,6 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1869,9 +1779,6 @@ exports[`Tree Props selectable with selectable 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1899,9 +1806,6 @@ exports[`Tree Props selectable with selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1980,9 +1884,6 @@ exports[`Tree Props selectable without selectable 1`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2010,9 +1911,6 @@ exports[`Tree Props selectable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2091,9 +1989,6 @@ exports[`Tree Props showIcon 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2121,9 +2016,6 @@ exports[`Tree Props showIcon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2198,9 +2090,6 @@ exports[`Tree Props showIcon 2`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2225,9 +2114,6 @@ exports[`Tree Props showIcon 2`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2299,9 +2185,6 @@ exports[`Tree Props showIcon 3`] = `
         >
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2333,9 +2216,6 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2367,9 +2247,6 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2404,9 +2281,6 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2438,9 +2312,6 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2561,9 +2432,6 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2591,9 +2459,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2621,9 +2486,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="1"
-            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2655,9 +2517,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
-            aria-level="1"
-            aria-posinset="2"
-            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2689,9 +2548,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="1"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2726,9 +2582,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="2"
-            aria-posinset="2"
-            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2763,9 +2616,6 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            aria-level="1"
-            aria-posinset="3"
-            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2844,9 +2694,6 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-expanded="false"
-            aria-level="0"
-            aria-posinset="0"
-            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -41,6 +41,10 @@ exports[`Tree Props checkStrictly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -72,6 +76,10 @@ exports[`Tree Props checkStrictly 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -154,6 +162,10 @@ exports[`Tree Props checkable default 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -185,6 +197,10 @@ exports[`Tree Props checkable default 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -267,6 +283,10 @@ exports[`Tree Props checkable without selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -298,6 +318,10 @@ exports[`Tree Props checkable without selectable 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -380,6 +404,10 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -406,6 +434,10 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -436,6 +468,10 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -466,6 +502,10 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -543,6 +583,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -573,6 +617,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -603,6 +651,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -629,6 +681,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -663,6 +719,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -697,6 +757,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -868,6 +932,10 @@ exports[`Tree Props defaultExpandAll 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -894,6 +962,10 @@ exports[`Tree Props defaultExpandAll 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -972,6 +1044,10 @@ exports[`Tree Props disabled basic 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1046,6 +1122,10 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1119,6 +1199,10 @@ exports[`Tree Props icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1149,6 +1233,10 @@ exports[`Tree Props icon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1230,6 +1318,10 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1261,6 +1353,10 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1343,6 +1439,10 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1374,6 +1474,10 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1456,6 +1560,10 @@ exports[`Tree Props loadData basic 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1479,6 +1587,10 @@ exports[`Tree Props loadData basic 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1553,6 +1665,10 @@ exports[`Tree Props multiple 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1579,6 +1695,10 @@ exports[`Tree Props multiple 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1748,6 +1868,10 @@ exports[`Tree Props selectable with selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1774,6 +1898,10 @@ exports[`Tree Props selectable with selectable 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1851,6 +1979,10 @@ exports[`Tree Props selectable without selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1877,6 +2009,10 @@ exports[`Tree Props selectable without selectable 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1954,6 +2090,10 @@ exports[`Tree Props showIcon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1980,6 +2120,10 @@ exports[`Tree Props showIcon 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2053,6 +2197,10 @@ exports[`Tree Props showIcon 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2076,6 +2224,10 @@ exports[`Tree Props showIcon 2`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2146,6 +2298,10 @@ exports[`Tree Props showIcon 3`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2176,6 +2332,10 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2206,6 +2366,10 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2239,6 +2403,10 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2269,6 +2437,10 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2388,6 +2560,10 @@ exports[`Tree Props treeData 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2414,6 +2590,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2440,6 +2620,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="0"
+            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2470,6 +2654,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="true"
+            aria-level="1"
+            aria-posinset="1"
+            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2500,6 +2688,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="0"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2533,6 +2725,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="2"
+            aria-posinset="1"
+            aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2566,6 +2762,10 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
+            aria-expanded="false"
+            aria-level="1"
+            aria-posinset="2"
+            aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2643,6 +2843,10 @@ exports[`Tree Props treeData 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-expanded="false"
+            aria-level="0"
+            aria-posinset="-1"
+            aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`Tree Props checkStrictly 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -78,7 +78,7 @@ exports[`Tree Props checkStrictly 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -164,7 +164,7 @@ exports[`Tree Props checkable default 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -199,7 +199,7 @@ exports[`Tree Props checkable default 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -285,7 +285,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -320,7 +320,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -406,7 +406,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -436,7 +436,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -470,7 +470,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -504,7 +504,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -585,7 +585,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -619,7 +619,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -653,7 +653,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -683,7 +683,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -721,7 +721,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -759,7 +759,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -934,7 +934,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -964,7 +964,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1046,7 +1046,7 @@ exports[`Tree Props disabled basic 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1124,7 +1124,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1201,7 +1201,7 @@ exports[`Tree Props icon 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1235,7 +1235,7 @@ exports[`Tree Props icon 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1320,7 +1320,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1355,7 +1355,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1441,7 +1441,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1476,7 +1476,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1562,7 +1562,7 @@ exports[`Tree Props loadData basic 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1589,7 +1589,7 @@ exports[`Tree Props loadData basic 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1667,7 +1667,7 @@ exports[`Tree Props multiple 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1697,7 +1697,7 @@ exports[`Tree Props multiple 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1870,7 +1870,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1900,7 +1900,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1981,7 +1981,7 @@ exports[`Tree Props selectable without selectable 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2011,7 +2011,7 @@ exports[`Tree Props selectable without selectable 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2092,7 +2092,7 @@ exports[`Tree Props showIcon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2122,7 +2122,7 @@ exports[`Tree Props showIcon 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2199,7 +2199,7 @@ exports[`Tree Props showIcon 2`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2226,7 +2226,7 @@ exports[`Tree Props showIcon 2`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2300,7 +2300,7 @@ exports[`Tree Props showIcon 3`] = `
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2334,7 +2334,7 @@ exports[`Tree Props showIcon 3`] = `
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2368,7 +2368,7 @@ exports[`Tree Props showIcon 3`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="1"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2405,7 +2405,7 @@ exports[`Tree Props showIcon 3`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2439,7 +2439,7 @@ exports[`Tree Props showIcon 3`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2562,7 +2562,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2592,7 +2592,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="true"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2622,7 +2622,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2656,7 +2656,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="true"
             aria-level="1"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2690,7 +2690,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="0"
+            aria-posinset="1"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2727,7 +2727,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="false"
             aria-level="2"
-            aria-posinset="1"
+            aria-posinset="2"
             aria-setsize="2"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2764,7 +2764,7 @@ exports[`Tree Props treeData 1`] = `
           <div
             aria-expanded="false"
             aria-level="1"
-            aria-posinset="2"
+            aria-posinset="3"
             aria-setsize="3"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2845,7 +2845,7 @@ exports[`Tree Props treeData 2`] = `
           <div
             aria-expanded="false"
             aria-level="0"
-            aria-posinset="-1"
+            aria-posinset="0"
             aria-setsize="0"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -53,6 +53,7 @@ exports[`Tree Props checkStrictly 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -89,6 +90,7 @@ exports[`Tree Props checkStrictly 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -166,6 +168,7 @@ exports[`Tree Props checkable default 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -202,6 +205,7 @@ exports[`Tree Props checkable default 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -279,6 +283,7 @@ exports[`Tree Props checkable without selectable 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -315,6 +320,7 @@ exports[`Tree Props checkable without selectable 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -1242,6 +1248,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -1278,6 +1285,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -1355,6 +1363,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />
@@ -1391,6 +1400,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
             />
             <span
               aria-checked="false"
+              aria-label="Select tree node"
               class="rc-tree-checkbox"
               role="checkbox"
             />

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -5,9 +5,11 @@ exports[`Tree Props checkStrictly 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -39,9 +41,9 @@ exports[`Tree Props checkStrictly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -51,7 +53,9 @@ exports[`Tree Props checkStrictly 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -68,9 +72,9 @@ exports[`Tree Props checkStrictly 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -84,7 +88,9 @@ exports[`Tree Props checkStrictly 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -112,9 +118,11 @@ exports[`Tree Props checkable default 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -146,9 +154,9 @@ exports[`Tree Props checkable default 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -158,7 +166,9 @@ exports[`Tree Props checkable default 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -175,9 +185,9 @@ exports[`Tree Props checkable default 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -191,7 +201,9 @@ exports[`Tree Props checkable default 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -219,9 +231,11 @@ exports[`Tree Props checkable without selectable 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -253,9 +267,9 @@ exports[`Tree Props checkable without selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -265,7 +279,9 @@ exports[`Tree Props checkable without selectable 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -282,9 +298,9 @@ exports[`Tree Props checkable without selectable 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -298,7 +314,9 @@ exports[`Tree Props checkable without selectable 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -326,9 +344,11 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -360,9 +380,9 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -386,9 +406,9 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -416,9 +436,9 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -446,9 +466,9 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -487,9 +507,11 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -521,9 +543,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -551,9 +573,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -581,9 +603,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -607,9 +629,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -641,9 +663,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -675,9 +697,9 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -716,9 +738,11 @@ exports[`Tree Props data and aria props renders aria attributes 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -761,9 +785,11 @@ exports[`Tree Props data and aria props renders data attributes 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -806,9 +832,11 @@ exports[`Tree Props defaultExpandAll 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -840,9 +868,9 @@ exports[`Tree Props defaultExpandAll 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -866,9 +894,9 @@ exports[`Tree Props defaultExpandAll 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -907,10 +935,12 @@ exports[`Tree Props disabled basic 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
       disabled=""
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -942,9 +972,9 @@ exports[`Tree Props disabled basic 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -979,10 +1009,12 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
       disabled=""
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1014,9 +1046,9 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1051,9 +1083,11 @@ exports[`Tree Props icon 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1085,9 +1119,9 @@ exports[`Tree Props icon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1115,9 +1149,9 @@ exports[`Tree Props icon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1160,9 +1194,11 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1194,9 +1230,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1206,7 +1242,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -1223,9 +1261,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1239,7 +1277,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -1267,9 +1307,11 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1301,9 +1343,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1313,7 +1355,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
               class="rc-tree-switcher rc-tree-switcher_open"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-open"
@@ -1330,9 +1374,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1346,7 +1390,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
               class="rc-tree-switcher rc-tree-switcher-noop"
             />
             <span
+              aria-checked="false"
               class="rc-tree-checkbox"
+              role="checkbox"
             />
             <span
               class="rc-tree-node-content-wrapper rc-tree-node-content-wrapper-normal"
@@ -1374,9 +1420,11 @@ exports[`Tree Props loadData basic 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1408,9 +1456,9 @@ exports[`Tree Props loadData basic 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1431,9 +1479,9 @@ exports[`Tree Props loadData basic 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1469,9 +1517,11 @@ exports[`Tree Props multiple 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1503,9 +1553,9 @@ exports[`Tree Props multiple 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1529,9 +1579,9 @@ exports[`Tree Props multiple 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1570,9 +1620,11 @@ exports[`Tree Props prefixCls 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1614,9 +1666,11 @@ exports[`Tree Props prefixCls 2`] = `
   class="test-prefix"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1658,9 +1712,11 @@ exports[`Tree Props selectable with selectable 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1692,9 +1748,9 @@ exports[`Tree Props selectable with selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1718,9 +1774,9 @@ exports[`Tree Props selectable with selectable 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1759,9 +1815,11 @@ exports[`Tree Props selectable without selectable 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1793,9 +1851,9 @@ exports[`Tree Props selectable without selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1819,9 +1877,9 @@ exports[`Tree Props selectable without selectable 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1860,9 +1918,11 @@ exports[`Tree Props showIcon 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1894,9 +1954,9 @@ exports[`Tree Props showIcon 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1920,9 +1980,9 @@ exports[`Tree Props showIcon 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -1957,9 +2017,11 @@ exports[`Tree Props showIcon 2`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1991,9 +2053,9 @@ exports[`Tree Props showIcon 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2014,9 +2076,9 @@ exports[`Tree Props showIcon 2`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2048,9 +2110,11 @@ exports[`Tree Props showIcon 3`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2082,9 +2146,9 @@ exports[`Tree Props showIcon 3`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2112,9 +2176,9 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2142,9 +2206,9 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2175,9 +2239,9 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2205,9 +2269,9 @@ exports[`Tree Props showIcon 3`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2242,9 +2306,11 @@ exports[`Tree Props showLine 1`] = `
   class="rc-tree rc-tree-show-line"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2286,9 +2352,11 @@ exports[`Tree Props treeData 1`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2320,9 +2388,9 @@ exports[`Tree Props treeData 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2346,9 +2414,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2372,9 +2440,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2402,9 +2470,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2432,9 +2500,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2465,9 +2533,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2498,9 +2566,9 @@ exports[`Tree Props treeData 1`] = `
             </span>
           </div>
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"
@@ -2539,9 +2607,11 @@ exports[`Tree Props treeData 2`] = `
   class="rc-tree"
   role="tree"
 >
-  <div>
+  <div
+    aria-hidden="true"
+  >
     <input
-      aria-label="for screen reader"
+      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2573,9 +2643,9 @@ exports[`Tree Props treeData 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            aria-grabbed="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
+            role="treeitem"
           >
             <span
               aria-hidden="true"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -3,13 +3,10 @@
 exports[`Tree Props checkStrictly 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -30,6 +27,7 @@ exports[`Tree Props checkStrictly 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -118,13 +116,10 @@ exports[`Tree Props checkStrictly 1`] = `
 exports[`Tree Props checkable default 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -145,6 +140,7 @@ exports[`Tree Props checkable default 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -233,13 +229,10 @@ exports[`Tree Props checkable default 1`] = `
 exports[`Tree Props checkable without selectable 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -260,6 +253,7 @@ exports[`Tree Props checkable without selectable 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -348,13 +342,10 @@ exports[`Tree Props checkable without selectable 1`] = `
 exports[`Tree Props custom switcher icon switcher icon 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -375,6 +366,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -515,13 +507,10 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
 exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -542,6 +531,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -752,13 +742,10 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
 exports[`Tree Props data and aria props renders aria attributes 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -780,6 +767,7 @@ exports[`Tree Props data and aria props renders aria attributes 1`] = `
   <div
     aria-label="name"
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -799,13 +787,10 @@ exports[`Tree Props data and aria props renders aria attributes 1`] = `
 exports[`Tree Props data and aria props renders data attributes 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -827,6 +812,7 @@ exports[`Tree Props data and aria props renders data attributes 1`] = `
   <div
     class="rc-tree-list"
     data-test="tree"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -846,13 +832,10 @@ exports[`Tree Props data and aria props renders data attributes 1`] = `
 exports[`Tree Props defaultExpandAll 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -873,6 +856,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -951,14 +935,11 @@ exports[`Tree Props defaultExpandAll 1`] = `
 exports[`Tree Props disabled basic 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
+      aria-label="for screen reader"
       disabled=""
-      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -979,6 +960,7 @@ exports[`Tree Props disabled basic 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1026,14 +1008,11 @@ exports[`Tree Props disabled basic 1`] = `
 exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
+      aria-label="for screen reader"
       disabled=""
-      role="presentation"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1054,6 +1033,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1101,13 +1081,10 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
 exports[`Tree Props icon 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1128,6 +1105,7 @@ exports[`Tree Props icon 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1214,13 +1192,10 @@ exports[`Tree Props icon 1`] = `
 exports[`Tree Props invalidate checkedKeys null 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1241,6 +1216,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1329,13 +1305,10 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
 exports[`Tree Props invalidate checkedKeys number 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1356,6 +1329,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1444,13 +1418,10 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
 exports[`Tree Props loadData basic 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1471,6 +1442,7 @@ exports[`Tree Props loadData basic 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1543,13 +1515,10 @@ exports[`Tree Props loadData basic 1`] = `
 exports[`Tree Props multiple 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1570,6 +1539,7 @@ exports[`Tree Props multiple 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1648,13 +1618,10 @@ exports[`Tree Props multiple 1`] = `
 exports[`Tree Props prefixCls 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1675,6 +1642,7 @@ exports[`Tree Props prefixCls 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1694,13 +1662,10 @@ exports[`Tree Props prefixCls 1`] = `
 exports[`Tree Props prefixCls 2`] = `
 <div
   class="test-prefix"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1721,6 +1686,7 @@ exports[`Tree Props prefixCls 2`] = `
   </div>
   <div
     class="test-prefix-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1740,13 +1706,10 @@ exports[`Tree Props prefixCls 2`] = `
 exports[`Tree Props selectable with selectable 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1767,6 +1730,7 @@ exports[`Tree Props selectable with selectable 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1845,13 +1809,10 @@ exports[`Tree Props selectable with selectable 1`] = `
 exports[`Tree Props selectable without selectable 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1872,6 +1833,7 @@ exports[`Tree Props selectable without selectable 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -1950,13 +1912,10 @@ exports[`Tree Props selectable without selectable 1`] = `
 exports[`Tree Props showIcon 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -1977,6 +1936,7 @@ exports[`Tree Props showIcon 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -2051,13 +2011,10 @@ exports[`Tree Props showIcon 1`] = `
 exports[`Tree Props showIcon 2`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2078,6 +2035,7 @@ exports[`Tree Props showIcon 2`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -2146,13 +2104,10 @@ exports[`Tree Props showIcon 2`] = `
 exports[`Tree Props showIcon 3`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2173,6 +2128,7 @@ exports[`Tree Props showIcon 3`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -2347,13 +2303,10 @@ exports[`Tree Props showIcon 3`] = `
 exports[`Tree Props showLine 1`] = `
 <div
   class="rc-tree rc-tree-show-line"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2374,6 +2327,7 @@ exports[`Tree Props showLine 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -2393,13 +2347,10 @@ exports[`Tree Props showLine 1`] = `
 exports[`Tree Props treeData 1`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2420,6 +2371,7 @@ exports[`Tree Props treeData 1`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div
@@ -2655,13 +2607,10 @@ exports[`Tree Props treeData 1`] = `
 exports[`Tree Props treeData 2`] = `
 <div
   class="rc-tree"
-  role="tree"
 >
-  <div
-    aria-hidden="true"
-  >
+  <div>
     <input
-      role="presentation"
+      aria-label="for screen reader"
       style="width: 0px; height: 0px; display: flex; overflow: hidden; opacity: 0; border: 0px; padding: 0px; margin: 0px;"
       tabindex="0"
       value=""
@@ -2682,6 +2631,7 @@ exports[`Tree Props treeData 2`] = `
   </div>
   <div
     class="rc-tree-list"
+    role="tree"
     style="position: relative;"
   >
     <div


### PR DESCRIPTION
- fix https://github.com/ant-design/ant-design/issues/51517

![image](https://github.com/user-attachments/assets/ab32906b-ad8a-4edf-8673-9c6fdf0cd0ab)
![image](https://github.com/user-attachments/assets/3547a430-8b6f-4ea2-91b2-76b44f154f83)

- input只是单纯用于键盘导航的，screen reader不用读取它的信息
- aria-grabbed在最新的ARIA 规范中也已经被废弃了
- 对于上面那个issue，我理解当`treeCheckable={true}`时，只需要让screen reader能够读取到CheckBox即可
- 为树节点添加了对应的`role="treeitem"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 改进了 `NodeList` 和 `TreeNode` 组件的可访问性，增强了对辅助技术的支持。
	- 更新了 `NodeList` 组件的运动效果处理逻辑，确保状态更新正确。
	- 在 `Tree` 组件中添加了 `role="tree"` 属性，进一步提升了可访问性。
- **文档**
	- 更新了 `.gitignore` 文件，添加了对 `.vscode` 目录的忽略。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->