### PR TITLE
feat: add `disabledStrategy` prop to support dynamic node disabled state calculation

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -180,7 +180,6 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
    */
   onActiveChange?: (key: Key) => void;
   filterTreeNode?: (treeNode: EventDataNode<TreeDataType>) => boolean;
-  disabledStrategy?: (node: DataNode) => boolean;
   motion?: any;
   switcherIcon?: IconType;
 
@@ -1403,7 +1402,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       direction,
       rootClassName,
       rootStyle,
-      disabledStrategy,
     } = this.props;
     const domProps: React.HTMLAttributes<HTMLDivElement> = pickAttrs(this.props, {
       aria: true,
@@ -1451,7 +1449,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           filterTreeNode,
 
           titleRender,
-          disabledStrategy,
 
           onNodeClick: this.onNodeClick,
           onNodeDoubleClick: this.onNodeDoubleClick,

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -180,6 +180,7 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
    */
   onActiveChange?: (key: Key) => void;
   filterTreeNode?: (treeNode: EventDataNode<TreeDataType>) => boolean;
+  disabledStrategy?: (node: DataNode) => boolean;
   motion?: any;
   switcherIcon?: IconType;
 
@@ -1402,6 +1403,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       direction,
       rootClassName,
       rootStyle,
+      disabledStrategy,
     } = this.props;
     const domProps: React.HTMLAttributes<HTMLDivElement> = pickAttrs(this.props, {
       aria: true,
@@ -1449,6 +1451,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           filterTreeNode,
 
           titleRender,
+          disabledStrategy,
 
           onNodeClick: this.onNodeClick,
           onNodeDoubleClick: this.onNodeDoubleClick,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -232,7 +232,6 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
 
   isDisabled = () => {
     const { disabled, data } = this.props;
-    console.log('treenode', data);
     const {
       context: { disabled: treeDisabled, disabledStrategy },
     } = this.props;
@@ -289,9 +288,6 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
       data,
       context: { draggable },
     } = this.props;
-
-    // 如果节点被禁用,则不可拖拽
-    if (this.isDisabled()) return false;
 
     return !!(draggable && (!draggable.nodeDraggable || draggable.nodeDraggable(data)));
   };

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -231,12 +231,13 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
   };
 
   isDisabled = () => {
-    const { disabled } = this.props;
+    const { disabled, data } = this.props;
+    console.log('treenode', data);
     const {
-      context: { disabled: treeDisabled },
+      context: { disabled: treeDisabled, disabledStrategy },
     } = this.props;
 
-    return !!(treeDisabled || disabled);
+    return !!(treeDisabled || disabled || (disabledStrategy && disabledStrategy(data)));
   };
 
   isCheckable = () => {
@@ -288,6 +289,9 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
       data,
       context: { draggable },
     } = this.props;
+
+    // 如果节点被禁用,则不可拖拽
+    if (this.isDisabled()) return false;
 
     return !!(draggable && (!draggable.nodeDraggable || draggable.nodeDraggable(data)));
   };

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import * as React from 'react';
 // @ts-ignore
-import { TreeContext, InternalContext, type TreeContextProps } from './contextTypes';
+import { TreeContext, UnstableContext, type TreeContextProps } from './contextTypes';
 import Indent from './Indent';
 import type { TreeNodeProps } from './interface';
 import getEntity from './utils/keyUtil';
@@ -17,7 +17,7 @@ export type { TreeNodeProps } from './interface';
 
 export interface InternalTreeNodeProps extends TreeNodeProps {
   context?: TreeContextProps;
-  internalContext?: React.ContextType<typeof InternalContext>;
+  unstableContext?: React.ContextType<typeof UnstableContext>;
 }
 
 export interface TreeNodeState {
@@ -235,7 +235,7 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
     const { disabled, data } = this.props;
     const {
       context: { disabled: treeDisabled },
-      internalContext: { nodeDisabled },
+      unstableContext: { nodeDisabled },
     } = this.props;
 
     return !!(treeDisabled || disabled || (nodeDisabled && nodeDisabled(data)));
@@ -599,11 +599,11 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
 const ContextTreeNode: React.FC<TreeNodeProps> = props => (
   <TreeContext.Consumer>
     {context => (
-      <InternalContext.Consumer>
-        {internalContext => (
-          <InternalTreeNode {...props} context={context} internalContext={internalContext} />
+      <UnstableContext.Consumer>
+        {unstableContext => (
+          <InternalTreeNode {...props} context={context} unstableContext={unstableContext} />
         )}
-      </InternalContext.Consumer>
+      </UnstableContext.Consumer>
     )}
   </TreeContext.Consumer>
 );

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import * as React from 'react';
 // @ts-ignore
-import { TreeContext, type TreeContextProps } from './contextTypes';
+import { TreeContext, InternalContext, type TreeContextProps } from './contextTypes';
 import Indent from './Indent';
 import type { TreeNodeProps } from './interface';
 import getEntity from './utils/keyUtil';
@@ -17,6 +17,7 @@ export type { TreeNodeProps } from './interface';
 
 export interface InternalTreeNodeProps extends TreeNodeProps {
   context?: TreeContextProps;
+  internalContext?: React.ContextType<typeof InternalContext>;
 }
 
 export interface TreeNodeState {
@@ -233,10 +234,11 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
   isDisabled = () => {
     const { disabled, data } = this.props;
     const {
-      context: { disabled: treeDisabled, disabledStrategy },
+      context: { disabled: treeDisabled },
+      internalContext: { nodeDisabled },
     } = this.props;
 
-    return !!(treeDisabled || disabled || (disabledStrategy && disabledStrategy(data)));
+    return !!(treeDisabled || disabled || (nodeDisabled && nodeDisabled(data)));
   };
 
   isCheckable = () => {
@@ -596,7 +598,13 @@ class InternalTreeNode extends React.Component<InternalTreeNodeProps, TreeNodeSt
 
 const ContextTreeNode: React.FC<TreeNodeProps> = props => (
   <TreeContext.Consumer>
-    {context => <InternalTreeNode {...props} context={context} />}
+    {context => (
+      <InternalContext.Consumer>
+        {internalContext => (
+          <InternalTreeNode {...props} context={context} internalContext={internalContext} />
+        )}
+      </InternalContext.Consumer>
+    )}
   </TreeContext.Consumer>
 );
 

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -94,3 +94,10 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
 }
 
 export const TreeContext: React.Context<TreeContextProps<any> | null> = React.createContext(null);
+
+/** Internal usage, safe to remove. Do not use in prod */
+export const InternalContext = React.createContext<{
+  nodeDisabled?: (node: DataNode) => boolean;
+}>({
+  nodeDisabled: undefined,
+});

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -70,6 +70,7 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
   loadData: (treeNode: EventDataNode<TreeDataType>) => Promise<void>;
   filterTreeNode: (treeNode: EventDataNode<TreeDataType>) => boolean;
   titleRender?: (node: any) => React.ReactNode;
+  disabledStrategy?: (node: DataNode) => boolean;
 
   onNodeClick: NodeMouseEventHandler<TreeDataType>;
   onNodeDoubleClick: NodeMouseEventHandler<TreeDataType>;

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -70,7 +70,6 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
   loadData: (treeNode: EventDataNode<TreeDataType>) => Promise<void>;
   filterTreeNode: (treeNode: EventDataNode<TreeDataType>) => boolean;
   titleRender?: (node: any) => React.ReactNode;
-  disabledStrategy?: (node: DataNode) => boolean;
 
   onNodeClick: NodeMouseEventHandler<TreeDataType>;
   onNodeDoubleClick: NodeMouseEventHandler<TreeDataType>;
@@ -96,8 +95,6 @@ export interface TreeContextProps<TreeDataType extends BasicDataNode = DataNode>
 export const TreeContext: React.Context<TreeContextProps<any> | null> = React.createContext(null);
 
 /** Internal usage, safe to remove. Do not use in prod */
-export const InternalContext = React.createContext<{
+export const UnstableContext = React.createContext<{
   nodeDisabled?: (node: DataNode) => boolean;
-}>({
-  nodeDisabled: undefined,
-});
+}>({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import Tree from './Tree';
 import TreeNode from './TreeNode';
 import type { TreeProps } from './Tree';
 import type { TreeNodeProps, BasicDataNode, FieldDataNode } from './interface';
+import { InternalContext } from './contextTypes';
 
-export { TreeNode };
+export { TreeNode, InternalContext };
 export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
 export default Tree;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import Tree from './Tree';
 import TreeNode from './TreeNode';
 import type { TreeProps } from './Tree';
 import type { TreeNodeProps, BasicDataNode, FieldDataNode } from './interface';
-import { InternalContext } from './contextTypes';
+import { UnstableContext } from './contextTypes';
 
-export { TreeNode, InternalContext };
+export { TreeNode, UnstableContext };
 export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
 export default Tree;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -69,7 +69,10 @@ export type Key = React.Key;
  */
 export type SafeKey = Exclude<Key, bigint>;
 
-export type KeyEntities<DateType extends BasicDataNode = any> = Record<SafeKey, DataEntity<DateType>>;
+export type KeyEntities<DateType extends BasicDataNode = any> = Record<
+  SafeKey,
+  DataEntity<DateType>
+>;
 
 export type DataNode = FieldDataNode<{
   key: Key;

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -6,7 +6,7 @@ import { resetWarned } from 'rc-util/lib/warning';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import Tree, { TreeNode } from '../src';
 import { objectMatcher, spyConsole, spyError } from './util';
-import { InternalContext } from '../src';
+import { UnstableContext } from '../src';
 
 const OPEN_CLASSNAME = 'rc-tree-switcher_open';
 const CHECKED_CLASSNAME = 'rc-tree-checkbox-checked';
@@ -1242,7 +1242,7 @@ describe('Tree Basic', () => {
   describe('nodeDisabled', () => {
     it('should disable node by nodeDisabled function', () => {
       const { getByRole } = render(
-        <InternalContext.Provider
+        <UnstableContext.Provider
           value={{
             nodeDisabled: node => node.key === '0-0-0',
           }}
@@ -1253,7 +1253,7 @@ describe('Tree Basic', () => {
               <TreeNode title="leaf 2" key="0-0-1" />
             </TreeNode>
           </Tree>
-        </InternalContext.Provider>,
+        </UnstableContext.Provider>,
       );
 
       expect(getByRole('treeitem', { name: 'leaf 1' })).toHaveClass('rc-tree-treenode-disabled');
@@ -1265,7 +1265,7 @@ describe('Tree Basic', () => {
     it('should work with checkable tree', () => {
       const onCheck = jest.fn();
       const { container } = render(
-        <InternalContext.Provider
+        <UnstableContext.Provider
           value={{
             nodeDisabled: node => node.key === '0-0-0',
           }}
@@ -1276,7 +1276,7 @@ describe('Tree Basic', () => {
               <TreeNode title="leaf 2" key="0-0-1" />
             </TreeNode>
           </Tree>
-        </InternalContext.Provider>,
+        </UnstableContext.Provider>,
       );
 
       fireEvent.click(container.querySelectorAll('.rc-tree-checkbox')[1]);
@@ -1289,7 +1289,7 @@ describe('Tree Basic', () => {
     it('should work with selectable tree', () => {
       const onSelect = jest.fn();
       const { container } = render(
-        <InternalContext.Provider
+        <UnstableContext.Provider
           value={{
             nodeDisabled: node => node.key === '0-0-0',
           }}
@@ -1300,7 +1300,7 @@ describe('Tree Basic', () => {
               <TreeNode title="leaf 2" key="0-0-1" />
             </TreeNode>
           </Tree>
-        </InternalContext.Provider>,
+        </UnstableContext.Provider>,
       );
 
       fireEvent.click(container.querySelectorAll('.rc-tree-node-content-wrapper')[1]);
@@ -1312,7 +1312,7 @@ describe('Tree Basic', () => {
 
     it('should override disabled prop', () => {
       const { getByRole } = render(
-        <InternalContext.Provider
+        <UnstableContext.Provider
           value={{
             nodeDisabled: node => node.key === '0-0-0',
           }}
@@ -1323,7 +1323,7 @@ describe('Tree Basic', () => {
               <TreeNode title="leaf 2" key="0-0-1" disabled />
             </TreeNode>
           </Tree>
-        </InternalContext.Provider>,
+        </UnstableContext.Provider>,
       );
 
       expect(getByRole('treeitem', { name: 'leaf 1' })).toHaveClass('rc-tree-treenode-disabled');

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable no-undef, react/no-multi-comp, no-console,
 react/no-unused-state, react/prop-types, no-return-assign */
 import React from 'react';
-import {render, fireEvent, act} from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { resetWarned } from 'rc-util/lib/warning';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import Tree, { TreeNode } from '../src';
 import { objectMatcher, spyConsole, spyError } from './util';
+import { InternalContext } from '../src';
 
 const OPEN_CLASSNAME = 'rc-tree-switcher_open';
 const CHECKED_CLASSNAME = 'rc-tree-checkbox-checked';
@@ -1055,9 +1056,9 @@ describe('Tree Basic', () => {
       render(<Tree ref={treeRef} />);
 
       act(() => {
-        treeRef.current.scrollTo({key: 'light', align: 'top'});
+        treeRef.current.scrollTo({ key: 'light', align: 'top' });
       });
-      
+
       jest.runAllTimers();
 
       expect(called).toBeTruthy();
@@ -1092,7 +1093,7 @@ describe('Tree Basic', () => {
       }
 
       const treeRef = React.createRef<any>();
-      
+
       const { container } = render(
         <Tree ref={treeRef} treeData={data} virtual itemHeight={20} height={100} />,
       );
@@ -1101,7 +1102,7 @@ describe('Tree Basic', () => {
         treeRef.current.scrollTo({ key: 5, offset: 5 });
         jest.runAllTimers();
       });
-      
+
       expect(container.querySelector('.rc-tree-list-holder').scrollTop).toEqual(25);
 
       jest.useRealTimers();
@@ -1236,5 +1237,97 @@ describe('Tree Basic', () => {
     expect(container.firstChild).toMatchSnapshot();
     expect(container.firstChild).toHaveClass('root-tree');
     expect(container.firstChild).toHaveStyle({ backgroundColor: 'cyan' });
+  });
+
+  describe('nodeDisabled', () => {
+    it('should disable node by nodeDisabled function', () => {
+      const { getByRole } = render(
+        <InternalContext.Provider
+          value={{
+            nodeDisabled: node => node.key === '0-0-0',
+          }}
+        >
+          <Tree defaultExpandAll>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+              <TreeNode title="leaf 2" key="0-0-1" />
+            </TreeNode>
+          </Tree>
+        </InternalContext.Provider>,
+      );
+
+      expect(getByRole('treeitem', { name: 'leaf 1' })).toHaveClass('rc-tree-treenode-disabled');
+      expect(getByRole('treeitem', { name: 'leaf 2' })).not.toHaveClass(
+        'rc-tree-treenode-disabled',
+      );
+    });
+
+    it('should work with checkable tree', () => {
+      const onCheck = jest.fn();
+      const { container } = render(
+        <InternalContext.Provider
+          value={{
+            nodeDisabled: node => node.key === '0-0-0',
+          }}
+        >
+          <Tree checkable defaultExpandAll onCheck={onCheck}>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+              <TreeNode title="leaf 2" key="0-0-1" />
+            </TreeNode>
+          </Tree>
+        </InternalContext.Provider>,
+      );
+
+      fireEvent.click(container.querySelectorAll('.rc-tree-checkbox')[1]);
+      expect(onCheck).not.toHaveBeenCalled();
+
+      fireEvent.click(container.querySelectorAll('.rc-tree-checkbox')[2]);
+      expect(onCheck).toHaveBeenCalled();
+    });
+
+    it('should work with selectable tree', () => {
+      const onSelect = jest.fn();
+      const { container } = render(
+        <InternalContext.Provider
+          value={{
+            nodeDisabled: node => node.key === '0-0-0',
+          }}
+        >
+          <Tree selectable defaultExpandAll onSelect={onSelect}>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" />
+              <TreeNode title="leaf 2" key="0-0-1" />
+            </TreeNode>
+          </Tree>
+        </InternalContext.Provider>,
+      );
+
+      fireEvent.click(container.querySelectorAll('.rc-tree-node-content-wrapper')[1]);
+      expect(onSelect).not.toHaveBeenCalled();
+
+      fireEvent.click(container.querySelectorAll('.rc-tree-node-content-wrapper')[2]);
+      expect(onSelect).toHaveBeenCalled();
+    });
+
+    it('should override disabled prop', () => {
+      const { getByRole } = render(
+        <InternalContext.Provider
+          value={{
+            nodeDisabled: node => node.key === '0-0-0',
+          }}
+        >
+          <Tree defaultExpandAll>
+            <TreeNode title="parent 1" key="0-0">
+              <TreeNode title="leaf 1" key="0-0-0" disabled={false} />
+              <TreeNode title="leaf 2" key="0-0-1" disabled />
+            </TreeNode>
+          </Tree>
+        </InternalContext.Provider>,
+      );
+
+      expect(getByRole('treeitem', { name: 'leaf 1' })).toHaveClass('rc-tree-treenode-disabled');
+      expect(getByRole('treeitem', { name: 'leaf 2' })).toHaveClass('rc-tree-treenode-disabled');
+    });
   });
 });


### PR DESCRIPTION
- ref https://github.com/react-component/tree-select/pull/596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 引入了 `UnstableContext`，增强了树节点的禁用状态管理。
	- 更新了 `InternalTreeNode` 和 `ContextTreeNode` 以支持新的上下文属性。
- **测试**
	- 新增测试用例以验证树组件在节点禁用时的行为。
- **文档**
	- 更新了接口和上下文的声明，以支持新功能。
- **样式**
	- 改进了 `KeyEntities` 类型的格式，使其更易读。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->