### PR TITLE
feat: Add classname to distinguish between leaf nodes or parent nodes

### DIFF
--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -430,7 +430,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         'drag-over-gap-top': !isDisabled && dragOverGapTop,
         'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
         'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-        [`${context.prefixCls}-leaf`]: data?.children,
+        [`${context.prefixCls}-leaf`]: !data?.children,
       })}
       style={style}
       // Draggable config

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -430,7 +430,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         'drag-over-gap-top': !isDisabled && dragOverGapTop,
         'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
         'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-        [`${context.prefixCls}-leaf`]: !hasChildren,
+        [`${context.prefixCls}-leaf`]: memoizedIsLeaf,
       })}
       style={style}
       // Draggable config

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -430,7 +430,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         'drag-over-gap-top': !isDisabled && dragOverGapTop,
         'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
         'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-        [`${context.prefixCls}-leaf`]: memoizedIsLeaf,
+        [`${context.prefixCls}-treenode-leaf`]: memoizedIsLeaf,
       })}
       style={style}
       // Draggable config

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -423,6 +423,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         [`${context.prefixCls}-treenode-active`]: active,
         [`${context.prefixCls}-treenode-leaf-last`]: isEndNode,
         [`${context.prefixCls}-treenode-draggable`]: isDraggable,
+        [`${context.prefixCls}-leaf`]: !data?.children,
         dragging,
         'drop-target': context.dropTargetKey === eventKey,
         'drop-container': context.dropContainerKey === eventKey,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -430,7 +430,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         'drag-over-gap-top': !isDisabled && dragOverGapTop,
         'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
         'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-        [`${context.prefixCls}-leaf`]: !data?.children,
+        [`${context.prefixCls}-leaf`]: !hasChildren,
       })}
       style={style}
       // Draggable config

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -413,25 +413,29 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       ref={domRef}
       role="treeitem"
       aria-expanded={isLeaf ? undefined : expanded}
-      className={classNames(className, `${context.prefixCls}-treenode`, {
-        [`${context.prefixCls}-treenode-disabled`]: isDisabled,
-        [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
-        [`${context.prefixCls}-treenode-checkbox-checked`]: checked,
-        [`${context.prefixCls}-treenode-checkbox-indeterminate`]: halfChecked,
-        [`${context.prefixCls}-treenode-selected`]: selected,
-        [`${context.prefixCls}-treenode-loading`]: loading,
-        [`${context.prefixCls}-treenode-active`]: active,
-        [`${context.prefixCls}-treenode-leaf-last`]: isEndNode,
-        [`${context.prefixCls}-treenode-draggable`]: isDraggable,
-        [`${context.prefixCls}-leaf`]: !data?.children,
-        dragging,
-        'drop-target': context.dropTargetKey === eventKey,
-        'drop-container': context.dropContainerKey === eventKey,
-        'drag-over': !isDisabled && dragOver,
-        'drag-over-gap-top': !isDisabled && dragOverGapTop,
-        'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
-        'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-      })}
+      className={classNames(
+        className,
+        `${context.prefixCls}-treenode`,
+        `${context.prefixCls}-${data?.children ? 'parent' : 'leaf'}`,
+        {
+          [`${context.prefixCls}-treenode-disabled`]: isDisabled,
+          [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
+          [`${context.prefixCls}-treenode-checkbox-checked`]: checked,
+          [`${context.prefixCls}-treenode-checkbox-indeterminate`]: halfChecked,
+          [`${context.prefixCls}-treenode-selected`]: selected,
+          [`${context.prefixCls}-treenode-loading`]: loading,
+          [`${context.prefixCls}-treenode-active`]: active,
+          [`${context.prefixCls}-treenode-leaf-last`]: isEndNode,
+          [`${context.prefixCls}-treenode-draggable`]: isDraggable,
+          dragging,
+          'drop-target': context.dropTargetKey === eventKey,
+          'drop-container': context.dropContainerKey === eventKey,
+          'drag-over': !isDisabled && dragOver,
+          'drag-over-gap-top': !isDisabled && dragOverGapTop,
+          'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
+          'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
+        },
+      )}
       style={style}
       // Draggable config
       draggable={draggableWithoutDisabled}

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -413,29 +413,25 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       ref={domRef}
       role="treeitem"
       aria-expanded={isLeaf ? undefined : expanded}
-      className={classNames(
-        className,
-        `${context.prefixCls}-treenode`,
-        `${context.prefixCls}-${data?.children ? 'parent' : 'leaf'}`,
-        {
-          [`${context.prefixCls}-treenode-disabled`]: isDisabled,
-          [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
-          [`${context.prefixCls}-treenode-checkbox-checked`]: checked,
-          [`${context.prefixCls}-treenode-checkbox-indeterminate`]: halfChecked,
-          [`${context.prefixCls}-treenode-selected`]: selected,
-          [`${context.prefixCls}-treenode-loading`]: loading,
-          [`${context.prefixCls}-treenode-active`]: active,
-          [`${context.prefixCls}-treenode-leaf-last`]: isEndNode,
-          [`${context.prefixCls}-treenode-draggable`]: isDraggable,
-          dragging,
-          'drop-target': context.dropTargetKey === eventKey,
-          'drop-container': context.dropContainerKey === eventKey,
-          'drag-over': !isDisabled && dragOver,
-          'drag-over-gap-top': !isDisabled && dragOverGapTop,
-          'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
-          'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
-        },
-      )}
+      className={classNames(className, `${context.prefixCls}-treenode`, {
+        [`${context.prefixCls}-treenode-disabled`]: isDisabled,
+        [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
+        [`${context.prefixCls}-treenode-checkbox-checked`]: checked,
+        [`${context.prefixCls}-treenode-checkbox-indeterminate`]: halfChecked,
+        [`${context.prefixCls}-treenode-selected`]: selected,
+        [`${context.prefixCls}-treenode-loading`]: loading,
+        [`${context.prefixCls}-treenode-active`]: active,
+        [`${context.prefixCls}-treenode-leaf-last`]: isEndNode,
+        [`${context.prefixCls}-treenode-draggable`]: isDraggable,
+        dragging,
+        'drop-target': context.dropTargetKey === eventKey,
+        'drop-container': context.dropContainerKey === eventKey,
+        'drag-over': !isDisabled && dragOver,
+        'drag-over-gap-top': !isDisabled && dragOverGapTop,
+        'drag-over-gap-bottom': !isDisabled && dragOverGapBottom,
+        'filter-node': context.filterTreeNode?.(convertNodePropsToEventData(props)),
+        [`${context.prefixCls}-leaf`]: data?.children,
+      })}
       style={style}
       // Draggable config
       draggable={draggableWithoutDisabled}

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1345,9 +1345,9 @@ describe('Tree Basic', () => {
     const treeNodes = container.querySelectorAll('[role="treeitem"]');
     treeNodes.forEach((item, index) => {
       if (result[index]?.children) {
-        expect(item).not.toHaveClass('rc-tree-leaf');
+        expect(item).not.toHaveClass('rc-tree-treenode-leaf');
       } else {
-        expect(item).toHaveClass('rc-tree-leaf');
+        expect(item).toHaveClass('rc-tree-treenode-leaf');
       }
     });
   });

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1312,4 +1312,44 @@ describe('Tree Basic', () => {
       expect(getByRole('treeitem', { name: 'leaf 2' })).toHaveClass('rc-tree-treenode-disabled');
     });
   });
+  it('leaf className', () => {
+    const data = [
+      {
+        title: '0-0',
+        key: '0-0',
+        children: [
+          { title: '0-0-0', key: '0-0-0' },
+          {
+            title: '0-0-1',
+            key: '0-0-1',
+            children: [
+              { title: '0-0-1-0', key: '0-0-1-0' },
+              { title: '0-0-1-1', key: '0-0-1-1' },
+            ],
+          },
+        ],
+      },
+      { title: '0-1', key: '0-1' },
+    ];
+    let result = [];
+    const recurse = currentArray => {
+      currentArray.forEach(item => {
+        result.push(item);
+        // 如果当前项有子项，则继续递归处理子项
+        if (item.children && item.children.length > 0) {
+          recurse(item.children);
+        }
+      });
+    };
+    recurse(data);
+    const { container } = render(<Tree treeData={data} expandedKeys={['0-0', '0-0-1']} />);
+    const treeNodes = container.querySelectorAll('[role="treeitem"]');
+    treeNodes.forEach((item, index) => {
+      if (result[index]?.children) {
+        expect(item).not.toHaveClass('rc-tree-leaf');
+      } else {
+        expect(item).toHaveClass('rc-tree-leaf');
+      }
+    });
+  });
 });

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1331,11 +1331,10 @@ describe('Tree Basic', () => {
       },
       { title: '0-1', key: '0-1' },
     ];
-    let result = [];
+    const result = [];
     const recurse = currentArray => {
       currentArray.forEach(item => {
         result.push(item);
-        // 如果当前项有子项，则继续递归处理子项
         if (item.children && item.children.length > 0) {
           recurse(item.children);
         }

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1331,24 +1331,11 @@ describe('Tree Basic', () => {
       },
       { title: '0-1', key: '0-1' },
     ];
-    const result = [];
-    const recurse = currentArray => {
-      currentArray.forEach(item => {
-        result.push(item);
-        if (item.children && item.children.length > 0) {
-          recurse(item.children);
-        }
-      });
-    };
-    recurse(data);
     const { container } = render(<Tree treeData={data} expandedKeys={['0-0', '0-0-1']} />);
     const treeNodes = container.querySelectorAll('[role="treeitem"]');
-    treeNodes.forEach((item, index) => {
-      if (result[index]?.children) {
-        expect(item).not.toHaveClass('rc-tree-treenode-leaf');
-      } else {
-        expect(item).toHaveClass('rc-tree-treenode-leaf');
-      }
-    });
+    const leafNodesCount = Array.from(treeNodes).filter(node =>
+      node.classList.contains('rc-tree-treenode-leaf'),
+    ).length;
+    expect(leafNodesCount).toBe(4);
   });
 });

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1332,10 +1332,7 @@ describe('Tree Basic', () => {
       { title: '0-1', key: '0-1' },
     ];
     const { container } = render(<Tree treeData={data} expandedKeys={['0-0', '0-0-1']} />);
-    const treeNodes = container.querySelectorAll('[role="treeitem"]');
-    const leafNodesCount = Array.from(treeNodes).filter(node =>
-      node.classList.contains('rc-tree-treenode-leaf'),
-    ).length;
-    expect(leafNodesCount).toBe(4);
+    const treeNodes = container.querySelectorAll('.rc-tree-treenode-leaf');
+    expect(treeNodes.length).toBe(4);
   });
 });

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -111,7 +111,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -226,7 +226,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -308,7 +308,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -386,7 +386,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -413,7 +413,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -485,7 +485,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -539,7 +539,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -570,7 +570,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -717,7 +717,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -757,7 +757,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -797,7 +797,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -953,7 +953,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -980,7 +980,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1007,7 +1007,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1034,7 +1034,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1061,7 +1061,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1088,7 +1088,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1115,7 +1115,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1142,7 +1142,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1169,7 +1169,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -111,7 +111,7 @@ exports[`Tree Basic check basic render 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -226,7 +226,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -308,7 +308,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -386,7 +386,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -413,7 +413,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -485,7 +485,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -539,7 +539,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -570,7 +570,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -717,7 +717,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -757,7 +757,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -797,7 +797,7 @@ exports[`Tree Basic renders correctly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -953,7 +953,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -980,7 +980,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1007,7 +1007,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1034,7 +1034,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1061,7 +1061,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1088,7 +1088,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1115,7 +1115,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1142,7 +1142,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1169,7 +1169,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -98,7 +98,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -132,7 +132,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -163,7 +163,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -235,7 +235,7 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -311,7 +311,7 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -387,7 +387,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -517,7 +517,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-0-0"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -552,7 +552,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -584,7 +584,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -716,7 +716,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-0-0"
             draggable="false"
             role="treeitem"
@@ -751,7 +751,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-1"
             draggable="false"
             role="treeitem"
@@ -783,7 +783,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-1"
             draggable="false"
             role="treeitem"
@@ -855,7 +855,7 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -878,7 +878,7 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -950,7 +950,7 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -976,7 +976,7 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -855,7 +855,7 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -950,7 +950,7 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1079,7 +1079,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -98,7 +98,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -132,7 +132,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -163,7 +163,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -235,7 +235,7 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -311,7 +311,7 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -387,7 +387,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -517,7 +517,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-0-0"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -552,7 +552,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -584,7 +584,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-1"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -716,7 +716,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             data-test="0-0-0-0"
             draggable="false"
             role="treeitem"
@@ -751,7 +751,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             data-test="0-0-1"
             draggable="false"
             role="treeitem"
@@ -783,7 +783,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             data-test="0-1"
             draggable="false"
             role="treeitem"
@@ -878,7 +878,7 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -976,7 +976,7 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
-            class="rc-tree-treenode rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1079,7 +1079,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tree Props checkStrictly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -188,7 +188,7 @@ exports[`Tree Props checkable default 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -303,7 +303,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -385,7 +385,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -443,7 +443,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -474,7 +474,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -550,7 +550,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -581,7 +581,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -639,7 +639,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -674,7 +674,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -709,7 +709,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -902,7 +902,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -979,7 +979,7 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1052,7 +1052,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1155,7 +1155,7 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1268,7 +1268,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1383,7 +1383,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1489,7 +1489,7 @@ exports[`Tree Props loadData basic 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1589,7 +1589,7 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1780,7 +1780,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1883,7 +1883,7 @@ exports[`Tree Props selectable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1986,7 +1986,7 @@ exports[`Tree Props showIcon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2082,7 +2082,7 @@ exports[`Tree Props showIcon 2`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2213,7 +2213,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2247,7 +2247,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2278,7 +2278,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2394,7 +2394,7 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2448,7 +2448,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2510,7 +2510,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2544,7 +2544,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2578,7 +2578,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2654,7 +2654,7 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -1489,7 +1489,7 @@ exports[`Tree Props loadData basic 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
           >

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tree Props checkStrictly 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -188,7 +188,7 @@ exports[`Tree Props checkable default 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -303,7 +303,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -385,7 +385,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -443,7 +443,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -474,7 +474,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -550,7 +550,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -581,7 +581,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -639,7 +639,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -674,7 +674,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -709,7 +709,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -902,7 +902,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -979,7 +979,7 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1052,7 +1052,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1155,7 +1155,7 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1268,7 +1268,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1383,7 +1383,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1589,7 +1589,7 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1780,7 +1780,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1883,7 +1883,7 @@ exports[`Tree Props selectable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -1986,7 +1986,7 @@ exports[`Tree Props showIcon 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2082,7 +2082,7 @@ exports[`Tree Props showIcon 2`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2213,7 +2213,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2247,7 +2247,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2278,7 +2278,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2394,7 +2394,7 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2448,7 +2448,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2510,7 +2510,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2544,7 +2544,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2578,7 +2578,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >
@@ -2654,7 +2654,7 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-expanded="false"
-            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-leaf"
+            class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
           >


### PR DESCRIPTION
 相关背景：
 - https://github.com/ant-design/ant-design/issues/31222
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **样式调整**
	- 为树节点添加了叶子节点的样式类，根据节点是否有子元素动态应用样式
- **测试增强**
	- 新增测试用例，验证树节点的叶子类名正确应用于无子元素的节点
<!-- end of auto-generated comment: release notes by coderabbit.ai -->