### PR TITLE
Fix context

### DIFF
--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -47,9 +47,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
   const [dragNodeHighlight, setDragNodeHighlight] = React.useState<boolean>(false);
 
   // ======= State: Disabled State =======
-  const isDisabled = React.useMemo<boolean>(() => {
-    return !!(context.disabled || props.disabled || unstableContext.nodeDisabled?.(data));
-  }, [context.disabled, props.disabled, unstableContext.nodeDisabled, data]);
+  const isDisabled = !!(context.disabled || props.disabled || unstableContext.nodeDisabled?.(data));
 
   const isCheckable = React.useMemo<React.ReactNode>(() => {
     // Return false if tree or treeNode is not checkable

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1311,6 +1311,35 @@ describe('Tree Basic', () => {
       expect(getByRole('treeitem', { name: 'leaf 1' })).toHaveClass('rc-tree-treenode-disabled');
       expect(getByRole('treeitem', { name: 'leaf 2' })).toHaveClass('rc-tree-treenode-disabled');
     });
+
+    it('correct handle closure', () => {
+      let disabled = false;
+      const nodeDisabled = () => disabled;
+
+      const singleTreeData = [
+        {
+          title: '0',
+          key: '0',
+        },
+      ];
+
+      const renderDemo = () => (
+        <UnstableContext.Provider
+          value={{
+            nodeDisabled,
+          }}
+        >
+          <Tree defaultExpandAll treeData={singleTreeData} />
+        </UnstableContext.Provider>
+      );
+
+      const { container, rerender } = render(renderDemo());
+      expect(container.querySelector('.rc-tree-treenode-disabled')).toBeFalsy();
+
+      disabled = true;
+      rerender(renderDemo());
+      expect(container.querySelector('.rc-tree-treenode-disabled')).toBeTruthy();
+    });
   });
   it('leaf className', () => {
     const data = [


### PR DESCRIPTION
在 #905 CC -> FC 的重构把 `isDisabled` 用 `useMemo` 包了起来。导致 UnstableContext 提供的闭包 disabled 切换会被 memo 掉。
去掉了 `useMemo` 还原为 CC 等效逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了树组件禁用状态的计算方式，改为直接判断，确保每次渲染时状态更新准确。
- **测试**
  - 增加了新的测试用例，以验证在动态场景下树节点禁用状态的正确切换。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->