### PR TITLE
feat(a11y): improve treeitem check/select acessibility

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -74,6 +74,7 @@ interface NodeListProps<TreeDataType extends BasicDataNode> {
   tabIndex: number;
   checkable?: boolean;
   selectable?: boolean;
+  multiselectable?: boolean;
   disabled?: boolean;
 
   expandedKeys: Key[];
@@ -141,6 +142,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
     prefixCls,
     data,
     selectable,
+    multiselectable,
     checkable,
     expandedKeys,
     selectedKeys,
@@ -330,6 +332,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         prefixCls={`${prefixCls}-list`}
         ref={listRef}
         role="tree"
+        aria-multiselectable={!multiselectable ? undefined : true}
         onVisibleChange={originList => {
           // The best match is using `fullList` - `originList` = `restList`
           // and check the `restList` to see if has the MOTION_KEY node

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1372,6 +1372,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       focusable,
       tabIndex = 0,
       selectable,
+      multiple,
       showIcon,
       icon,
       switcherIcon,
@@ -1473,6 +1474,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
             data={flattenNodes}
             disabled={disabled}
             selectable={selectable}
+            multiselectable={multiple}
             checkable={!!checkable}
             motion={motion}
             dragging={draggingNodeKey !== null}

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -415,7 +415,9 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
   const draggableWithoutDisabled = !isDisabled && isDraggable;
 
   const dragging = context.draggingNodeKey === eventKey;
-  const ariaSelected = selectable !== undefined ? { 'aria-selected': !!selectable } : undefined;
+  const ariaSelected = isSelectable ? { 'aria-selected': !!selected } : undefined;
+  const ariaChecked = isCheckable ? { 'aria-checked': !!checked } : undefined;
+
   return (
     <div
       ref={domRef}
@@ -452,6 +454,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       onDragEnd={isDraggable ? onDragEnd : undefined}
       onMouseMove={onMouseMove}
       {...ariaSelected}
+      {...ariaChecked}
       {...dataOrAriaAttributeProps}
     >
       <Indent prefixCls={context.prefixCls} level={level} isStart={isStart} isEnd={isEnd} />

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -47,6 +47,8 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
 
   const [dragNodeHighlight, setDragNodeHighlight] = React.useState<boolean>(false);
 
+  const ariaId = React.useId();
+
   // ======= State: Disabled State =======
   const isDisabled = !!(context.disabled || props.disabled || unstableContext.nodeDisabled?.(data));
 
@@ -382,6 +384,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       >
         {$icon}
         <span
+          id={`${context.prefixCls}-title-${ariaId}`}
           className={classNames(`${context.prefixCls}-title`, treeClassNames?.itemTitle)}
           style={styles?.itemTitle}
         >
@@ -423,6 +426,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       ref={domRef}
       role="treeitem"
       aria-expanded={isLeaf ? undefined : expanded}
+      aria-labelledby={`${context.prefixCls}-title-${ariaId}`}
       className={classNames(className, `${context.prefixCls}-treenode`, treeClassNames?.item, {
         [`${context.prefixCls}-treenode-disabled`]: isDisabled,
         [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,

--- a/tests/TreeNodeProps.spec.tsx
+++ b/tests/TreeNodeProps.spec.tsx
@@ -198,8 +198,8 @@ describe('TreeNode Props', () => {
     }
 
     const { container } = render(<Demo />);
-    // tree selectable is false ,then children should be selectable = false if not set selectable alone.
-    expect(container.querySelectorAll('[aria-selected=false]')).toHaveLength(1);
+    // tree selectable is false, then no treeitem should have aria-selected (neither true or false)
+    expect(container.querySelectorAll('[aria-selected]')).toHaveLength(0);
 
     fireEvent.click(container.querySelector('.rc-tree-node-content-wrapper'));
     expect(onClick).toHaveBeenCalled();
@@ -209,7 +209,8 @@ describe('TreeNode Props', () => {
     fireEvent.click(container.querySelector('.test-button'));
     onClick.mockRestore();
     onSelect.mockRestore();
-    expect(container.querySelectorAll('[aria-selected=false]')).toHaveLength(1);
+    // tree selectable is true, but only one treeitem is selectable
+    expect(container.querySelectorAll('[aria-selected]')).toHaveLength(1);
     fireEvent.click(container.querySelectorAll('.rc-tree-node-content-wrapper')[1]);
     expect(onClick).toHaveBeenCalled();
     expect(onSelect).not.toHaveBeenCalled();

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -39,7 +39,9 @@ exports[`Tree Basic check basic render 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -72,7 +74,9 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -110,7 +114,9 @@ exports[`Tree Basic check basic render 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -192,7 +198,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="true"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -225,7 +233,9 @@ exports[`Tree Basic check check after data ready works 1`] = `
             </span>
           </div>
           <div
+            aria-checked="true"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -307,7 +317,9 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="true"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -386,6 +398,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -413,6 +426,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -485,6 +499,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -512,6 +527,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -539,6 +555,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -570,6 +587,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -645,7 +663,9 @@ exports[`Tree Basic renders correctly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -678,7 +698,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -716,7 +738,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -756,7 +780,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -796,7 +822,9 @@ exports[`Tree Basic renders correctly 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -880,6 +908,7 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -953,6 +982,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -980,6 +1010,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1007,6 +1038,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1034,6 +1066,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1061,6 +1094,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1088,6 +1122,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1115,6 +1150,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1142,6 +1178,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1169,6 +1206,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -650,6 +650,7 @@ exports[`Tree Basic renders correctly 1`] = `
     </div>
   </div>
   <div
+    aria-multiselectable="true"
     class="rc-tree-list"
     role="tree"
     style="position: relative;"

--- a/tests/__snapshots__/Tree.spec.tsx.snap
+++ b/tests/__snapshots__/Tree.spec.tsx.snap
@@ -41,6 +41,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rs:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -68,6 +69,7 @@ exports[`Tree Basic check basic render 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rs:"
               >
                 ---
               </span>
@@ -76,6 +78,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rt:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -108,6 +111,7 @@ exports[`Tree Basic check basic render 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rt:"
               >
                 ---
               </span>
@@ -116,6 +120,7 @@ exports[`Tree Basic check basic render 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ru:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -147,6 +152,7 @@ exports[`Tree Basic check basic render 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ru:"
               >
                 ---
               </span>
@@ -200,6 +206,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           <div
             aria-checked="true"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1p:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last"
             draggable="false"
@@ -227,6 +234,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1p:"
               >
                 Light
               </span>
@@ -235,6 +243,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
           <div
             aria-checked="true"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1q:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -266,6 +275,7 @@ exports[`Tree Basic check check after data ready works 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1q:"
               >
                 Bamboo
               </span>
@@ -319,6 +329,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
           <div
             aria-checked="true"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1o:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-checkbox-checked rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -346,6 +357,7 @@ exports[`Tree Basic check check update when Tree trigger componentWillReceivePro
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1o:"
               >
                 parent 1
               </span>
@@ -398,6 +410,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r34:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -419,6 +432,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r34:"
               >
                 00
               </span>
@@ -426,6 +440,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r35:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -447,6 +462,7 @@ exports[`Tree Basic ignore illegal node as Tree children Direct TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r35:"
               >
                 02
               </span>
@@ -499,6 +515,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r36:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -520,6 +537,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r36:"
               >
                 00
               </span>
@@ -527,6 +545,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r37:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -548,6 +567,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r37:"
               >
                 01
               </span>
@@ -555,6 +575,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r38:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -580,6 +601,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r38:"
               >
                 010
               </span>
@@ -587,6 +609,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r39:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -612,6 +635,7 @@ exports[`Tree Basic ignore illegal node as Tree children Sub TreeNode 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r39:"
               >
                 012
               </span>
@@ -666,6 +690,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r0:"
             aria-selected="false"
             class="spe rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -693,6 +718,7 @@ exports[`Tree Basic renders correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r0:"
               >
                 parent 1
               </span>
@@ -701,6 +727,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-open"
             draggable="false"
@@ -733,6 +760,7 @@ exports[`Tree Basic renders correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1:"
               >
                 leaf 1
               </span>
@@ -741,6 +769,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r2:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -775,6 +804,7 @@ exports[`Tree Basic renders correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r2:"
               >
                 leaf
               </span>
@@ -783,6 +813,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r3:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -817,6 +848,7 @@ exports[`Tree Basic renders correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r3:"
               >
                 leaf
               </span>
@@ -825,6 +857,7 @@ exports[`Tree Basic renders correctly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r4:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -857,6 +890,7 @@ exports[`Tree Basic renders correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r4:"
               >
                 leaf 2
               </span>
@@ -909,6 +943,7 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r33:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -930,6 +965,7 @@ exports[`Tree Basic renders opaque children correctly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r33:"
               >
                 0
               </span>
@@ -983,6 +1019,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r70:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1004,6 +1041,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r70:"
               >
                 0
               </span>
@@ -1011,6 +1049,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r71:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1032,6 +1071,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r71:"
               >
                 1
               </span>
@@ -1039,6 +1079,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r72:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1060,6 +1101,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r72:"
               >
                 2
               </span>
@@ -1067,6 +1109,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r73:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1088,6 +1131,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r73:"
               >
                 3
               </span>
@@ -1095,6 +1139,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r74:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1116,6 +1161,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r74:"
               >
                 4
               </span>
@@ -1123,6 +1169,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r75:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1144,6 +1191,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r75:"
               >
                 5
               </span>
@@ -1151,6 +1199,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r76:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1172,6 +1221,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r76:"
               >
                 6
               </span>
@@ -1179,6 +1229,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r77:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -1200,6 +1251,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r77:"
               >
                 7
               </span>
@@ -1207,6 +1259,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r78:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1228,6 +1281,7 @@ exports[`Tree Basic should support rootStyle and rootClassName 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r78:"
               >
                 8
               </span>

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -40,6 +40,7 @@ exports[`TreeNode Props className 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r0:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -61,6 +62,7 @@ exports[`TreeNode Props className 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r0:"
               >
                 ---
               </span>
@@ -68,6 +70,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1:"
             aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -93,6 +96,7 @@ exports[`TreeNode Props className 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1:"
               >
                 ---
               </span>
@@ -100,6 +104,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r2:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -128,6 +133,7 @@ exports[`TreeNode Props className 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r2:"
               >
                 ---
               </span>
@@ -135,6 +141,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r3:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -160,6 +167,7 @@ exports[`TreeNode Props className 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r3:"
               >
                 ---
               </span>
@@ -167,6 +175,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r4:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -188,6 +197,7 @@ exports[`TreeNode Props className 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r4:"
               >
                 ---
               </span>
@@ -240,6 +250,7 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rd:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -265,6 +276,7 @@ exports[`TreeNode Props customize icon component 1`] = `
               </span>
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rd:"
               >
                 ---
               </span>
@@ -317,6 +329,7 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rc:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -342,6 +355,7 @@ exports[`TreeNode Props customize icon element 1`] = `
               </span>
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rc:"
               >
                 ---
               </span>
@@ -394,6 +408,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:re:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -412,6 +427,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:re:"
               >
                 ---
               </span>
@@ -465,6 +481,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0"
+            aria-labelledby="rc-tree-title-:rl:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -486,6 +503,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rl:"
               >
                 ---
               </span>
@@ -494,6 +512,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0-0"
+            aria-labelledby="rc-tree-title-:rm:"
             aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -519,6 +538,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rm:"
               >
                 ---
               </span>
@@ -527,6 +547,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-0-0"
+            aria-labelledby="rc-tree-title-:rn:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -555,6 +576,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rn:"
               >
                 ---
               </span>
@@ -563,6 +585,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-1"
+            aria-labelledby="rc-tree-title-:ro:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -588,6 +611,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ro:"
               >
                 ---
               </span>
@@ -596,6 +620,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-1"
+            aria-labelledby="rc-tree-title-:rp:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -617,6 +642,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rp:"
               >
                 ---
               </span>
@@ -669,6 +695,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rg:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
@@ -691,6 +718,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rg:"
               >
                 ---
               </span>
@@ -698,6 +726,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rh:"
             aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
@@ -724,6 +753,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rh:"
               >
                 ---
               </span>
@@ -731,6 +761,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ri:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-0-0"
@@ -760,6 +791,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ri:"
               >
                 ---
               </span>
@@ -767,6 +799,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rj:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-1"
@@ -793,6 +826,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rj:"
               >
                 ---
               </span>
@@ -800,6 +834,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rk:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-1"
@@ -822,6 +857,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rk:"
               >
                 ---
               </span>
@@ -873,6 +909,7 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-labelledby="rc-tree-title-:r5:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -891,12 +928,14 @@ exports[`TreeNode Props isLeaf 1`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r5:"
               >
                 ---
               </span>
             </span>
           </div>
           <div
+            aria-labelledby="rc-tree-title-:r6:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -919,6 +958,7 @@ exports[`TreeNode Props isLeaf 1`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r6:"
               >
                 ---
               </span>
@@ -970,6 +1010,7 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-labelledby="rc-tree-title-:r7:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -991,12 +1032,14 @@ exports[`TreeNode Props isLeaf 2`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r7:"
               >
                 ---
               </span>
             </span>
           </div>
           <div
+            aria-labelledby="rc-tree-title-:r8:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1022,6 +1065,7 @@ exports[`TreeNode Props isLeaf 2`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r8:"
               >
                 ---
               </span>
@@ -1074,6 +1118,7 @@ exports[`TreeNode Props isLeaf 3`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r9:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1095,6 +1140,7 @@ exports[`TreeNode Props isLeaf 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r9:"
               >
                 ---
               </span>
@@ -1102,6 +1148,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ra:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1127,6 +1174,7 @@ exports[`TreeNode Props isLeaf 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ra:"
               >
                 ---
               </span>

--- a/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeNodeProps.spec.tsx.snap
@@ -40,6 +40,7 @@ exports[`TreeNode Props className 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -67,6 +68,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -98,6 +100,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -132,6 +135,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -163,6 +167,7 @@ exports[`TreeNode Props className 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -235,6 +240,7 @@ exports[`TreeNode Props customize icon component 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -311,6 +317,7 @@ exports[`TreeNode Props customize icon element 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -387,6 +394,7 @@ exports[`TreeNode Props customize icon hide icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -457,6 +465,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -485,6 +494,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="true"
             aria-label="0-0-0"
+            aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -517,6 +527,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-0-0"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -552,6 +563,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-0-1"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -584,6 +596,7 @@ exports[`TreeNode Props data and aria props renders aria attributes on li 1`] = 
           <div
             aria-expanded="false"
             aria-label="0-1"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -656,6 +669,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0"
             draggable="false"
@@ -684,6 +698,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="tree-node-cls rc-tree-treenode rc-tree-treenode-switcher-open"
             data-test="0-0-0"
             draggable="false"
@@ -716,6 +731,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-0-0"
             draggable="false"
@@ -751,6 +767,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-0-1"
             draggable="false"
@@ -783,6 +800,7 @@ exports[`TreeNode Props data and aria props renders data attributes on li 1`] = 
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             data-test="0-1"
             draggable="false"
@@ -855,6 +873,7 @@ exports[`TreeNode Props isLeaf 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -878,6 +897,7 @@ exports[`TreeNode Props isLeaf 1`] = `
             </span>
           </div>
           <div
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -950,6 +970,7 @@ exports[`TreeNode Props isLeaf 2`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -976,6 +997,7 @@ exports[`TreeNode Props isLeaf 2`] = `
             </span>
           </div>
           <div
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1052,6 +1074,7 @@ exports[`TreeNode Props isLeaf 3`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1079,6 +1102,7 @@ exports[`TreeNode Props isLeaf 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -1584,6 +1584,7 @@ exports[`Tree Props multiple 1`] = `
     </div>
   </div>
   <div
+    aria-multiselectable="true"
     class="rc-tree-list"
     role="tree"
     style="position: relative;"

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -41,6 +41,7 @@ exports[`Tree Props checkStrictly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rp:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -68,6 +69,7 @@ exports[`Tree Props checkStrictly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rp:"
               >
                 ---
               </span>
@@ -76,6 +78,7 @@ exports[`Tree Props checkStrictly 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rq:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -107,6 +110,7 @@ exports[`Tree Props checkStrictly 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rq:"
               >
                 ---
               </span>
@@ -160,6 +164,7 @@ exports[`Tree Props checkable default 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rf:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -187,6 +192,7 @@ exports[`Tree Props checkable default 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rf:"
               >
                 ---
               </span>
@@ -195,6 +201,7 @@ exports[`Tree Props checkable default 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rg:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -226,6 +233,7 @@ exports[`Tree Props checkable default 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rg:"
               >
                 ---
               </span>
@@ -279,6 +287,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rh:"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -305,6 +314,7 @@ exports[`Tree Props checkable without selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rh:"
               >
                 ---
               </span>
@@ -313,6 +323,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ri:"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -343,6 +354,7 @@ exports[`Tree Props checkable without selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ri:"
               >
                 ---
               </span>
@@ -395,6 +407,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1u:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -416,6 +429,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1u:"
               >
                 ---
               </span>
@@ -423,6 +437,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1v:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -448,6 +463,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1v:"
               >
                 ---
               </span>
@@ -455,6 +471,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r20:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -480,6 +497,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r20:"
               >
                 ---
               </span>
@@ -487,6 +505,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r21:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -512,6 +531,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r21:"
               >
                 ---
               </span>
@@ -564,6 +584,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r22:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -589,6 +610,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r22:"
               >
                 ---
               </span>
@@ -596,6 +618,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r23:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -621,6 +644,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r23:"
               >
                 ---
               </span>
@@ -628,6 +652,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r24:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -649,6 +674,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r24:"
               >
                 ---
               </span>
@@ -656,6 +682,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r25:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -685,6 +712,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r25:"
               >
                 ---
               </span>
@@ -692,6 +720,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r26:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -721,6 +750,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r26:"
               >
                 ---
               </span>
@@ -728,6 +758,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r27:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -753,6 +784,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r27:"
               >
                 ---
               </span>
@@ -895,6 +927,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rr:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -916,6 +949,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rr:"
               >
                 parent
               </span>
@@ -923,6 +957,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rs:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -948,6 +983,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rs:"
               >
                 child
               </span>
@@ -1001,6 +1037,7 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1s:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1022,6 +1059,7 @@ exports[`Tree Props disabled basic 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1s:"
               >
                 ---
               </span>
@@ -1075,6 +1113,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1t:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1096,6 +1135,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1t:"
               >
                 ---
               </span>
@@ -1148,6 +1188,7 @@ exports[`Tree Props icon 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1b:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1173,6 +1214,7 @@ exports[`Tree Props icon 1`] = `
               </span>
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1b:"
               >
                 ---
               </span>
@@ -1180,6 +1222,7 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1c:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1209,6 +1252,7 @@ exports[`Tree Props icon 1`] = `
               </span>
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1c:"
               >
                 ---
               </span>
@@ -1262,6 +1306,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rl:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1289,6 +1334,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rl:"
               >
                 ---
               </span>
@@ -1297,6 +1343,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rm:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1328,6 +1375,7 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rm:"
               >
                 ---
               </span>
@@ -1381,6 +1429,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           <div
             aria-checked="false"
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rn:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1408,6 +1457,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rn:"
               >
                 ---
               </span>
@@ -1416,6 +1466,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           <div
             aria-checked="false"
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ro:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1447,6 +1498,7 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ro:"
               >
                 ---
               </span>
@@ -1499,6 +1551,7 @@ exports[`Tree Props loadData basic 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rt:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1517,6 +1570,7 @@ exports[`Tree Props loadData basic 1`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rt:"
               >
                 ---
               </span>
@@ -1524,6 +1578,7 @@ exports[`Tree Props loadData basic 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ru:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1546,6 +1601,7 @@ exports[`Tree Props loadData basic 1`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ru:"
               >
                 ---
               </span>
@@ -1599,6 +1655,7 @@ exports[`Tree Props multiple 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rd:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1620,6 +1677,7 @@ exports[`Tree Props multiple 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rd:"
               >
                 ---
               </span>
@@ -1627,6 +1685,7 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:re:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1652,6 +1711,7 @@ exports[`Tree Props multiple 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:re:"
               >
                 ---
               </span>
@@ -1792,6 +1852,7 @@ exports[`Tree Props selectable with selectable 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:rb:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -1813,6 +1874,7 @@ exports[`Tree Props selectable with selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rb:"
               >
                 ---
               </span>
@@ -1820,6 +1882,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:rc:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -1845,6 +1908,7 @@ exports[`Tree Props selectable with selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:rc:"
               >
                 ---
               </span>
@@ -1897,6 +1961,7 @@ exports[`Tree Props selectable without selectable 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r9:"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1917,6 +1982,7 @@ exports[`Tree Props selectable without selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r9:"
               >
                 ---
               </span>
@@ -1924,6 +1990,7 @@ exports[`Tree Props selectable without selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:ra:"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1948,6 +2015,7 @@ exports[`Tree Props selectable without selectable 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:ra:"
               >
                 ---
               </span>
@@ -2000,6 +2068,7 @@ exports[`Tree Props showIcon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r0:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2021,6 +2090,7 @@ exports[`Tree Props showIcon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r0:"
               >
                 ---
               </span>
@@ -2028,6 +2098,7 @@ exports[`Tree Props showIcon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2049,6 +2120,7 @@ exports[`Tree Props showIcon 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1:"
               >
                 ---
               </span>
@@ -2101,6 +2173,7 @@ exports[`Tree Props showIcon 2`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r2:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
@@ -2119,6 +2192,7 @@ exports[`Tree Props showIcon 2`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r2:"
               >
                 ---
               </span>
@@ -2126,6 +2200,7 @@ exports[`Tree Props showIcon 2`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r3:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2144,6 +2219,7 @@ exports[`Tree Props showIcon 2`] = `
             >
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r3:"
               >
                 ---
               </span>
@@ -2196,6 +2272,7 @@ exports[`Tree Props showIcon 3`] = `
         >
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r4:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2221,6 +2298,7 @@ exports[`Tree Props showIcon 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r4:"
               >
                 ---
               </span>
@@ -2228,6 +2306,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r5:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2253,6 +2332,7 @@ exports[`Tree Props showIcon 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r5:"
               >
                 ---
               </span>
@@ -2260,6 +2340,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r6:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2288,6 +2369,7 @@ exports[`Tree Props showIcon 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r6:"
               >
                 ---
               </span>
@@ -2295,6 +2377,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r7:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2320,6 +2403,7 @@ exports[`Tree Props showIcon 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r7:"
               >
                 ---
               </span>
@@ -2327,6 +2411,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r8:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2348,6 +2433,7 @@ exports[`Tree Props showIcon 3`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r8:"
               >
                 ---
               </span>
@@ -2444,6 +2530,7 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1l:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -2465,6 +2552,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1l:"
               >
                 T0
               </span>
@@ -2472,6 +2560,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1m:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -2493,6 +2582,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1m:"
               >
                 T1
               </span>
@@ -2500,6 +2590,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1n:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -2525,6 +2616,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1n:"
               >
                 T10
               </span>
@@ -2532,6 +2624,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-labelledby="rc-tree-title-:r1o:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
@@ -2557,6 +2650,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1o:"
               >
                 T11
               </span>
@@ -2564,6 +2658,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1p:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
@@ -2592,6 +2687,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1p:"
               >
                 T110
               </span>
@@ -2599,6 +2695,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1q:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2627,6 +2724,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1q:"
               >
                 T111
               </span>
@@ -2634,6 +2732,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1r:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2659,6 +2758,7 @@ exports[`Tree Props treeData 1`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1r:"
               >
                 T12
               </span>
@@ -2711,6 +2811,7 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-expanded="false"
+            aria-labelledby="rc-tree-title-:r1l:"
             aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -2732,6 +2833,7 @@ exports[`Tree Props treeData 2`] = `
               />
               <span
                 class="rc-tree-title"
+                id="rc-tree-title-:r1l:"
               >
                 T0
               </span>

--- a/tests/__snapshots__/TreeProps.spec.tsx.snap
+++ b/tests/__snapshots__/TreeProps.spec.tsx.snap
@@ -39,7 +39,9 @@ exports[`Tree Props checkStrictly 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -72,7 +74,9 @@ exports[`Tree Props checkStrictly 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -154,7 +158,9 @@ exports[`Tree Props checkable default 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -187,7 +193,9 @@ exports[`Tree Props checkable default 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -269,6 +277,7 @@ exports[`Tree Props checkable without selectable 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
@@ -302,6 +311,7 @@ exports[`Tree Props checkable without selectable 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
@@ -385,6 +395,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -412,6 +423,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -443,6 +455,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -474,6 +487,7 @@ exports[`Tree Props custom switcher icon switcher icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -550,6 +564,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -581,6 +596,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -612,6 +628,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -639,6 +656,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -674,6 +692,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -709,6 +728,7 @@ exports[`Tree Props custom switcher icon switcher leaf icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -875,6 +895,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -902,6 +923,7 @@ exports[`Tree Props defaultExpandAll 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -979,6 +1001,7 @@ exports[`Tree Props disabled basic 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1052,6 +1075,7 @@ exports[`Tree Props disabled treeNode should disabled when tree disabled 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-disabled rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1124,6 +1148,7 @@ exports[`Tree Props icon 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1155,6 +1180,7 @@ exports[`Tree Props icon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1234,7 +1260,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1267,7 +1295,9 @@ exports[`Tree Props invalidate checkedKeys null 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1349,7 +1379,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
           style="display: flex; flex-direction: column;"
         >
           <div
+            aria-checked="false"
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1382,7 +1414,9 @@ exports[`Tree Props invalidate checkedKeys number 1`] = `
             </span>
           </div>
           <div
+            aria-checked="false"
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1465,6 +1499,7 @@ exports[`Tree Props loadData basic 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1489,6 +1524,7 @@ exports[`Tree Props loadData basic 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1562,6 +1598,7 @@ exports[`Tree Props multiple 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1589,6 +1626,7 @@ exports[`Tree Props multiple 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1753,6 +1791,7 @@ exports[`Tree Props selectable with selectable 1`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -1780,6 +1819,7 @@ exports[`Tree Props selectable with selectable 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -1959,6 +1999,7 @@ exports[`Tree Props showIcon 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -1986,6 +2027,7 @@ exports[`Tree Props showIcon 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2058,6 +2100,7 @@ exports[`Tree Props showIcon 2`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close"
             draggable="false"
             role="treeitem"
@@ -2082,6 +2125,7 @@ exports[`Tree Props showIcon 2`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2151,6 +2195,7 @@ exports[`Tree Props showIcon 3`] = `
         >
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2182,6 +2227,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2213,6 +2259,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2247,6 +2294,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2278,6 +2326,7 @@ exports[`Tree Props showIcon 3`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2394,6 +2443,7 @@ exports[`Tree Props treeData 1`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2421,6 +2471,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open rc-tree-treenode-leaf-last"
             draggable="false"
             role="treeitem"
@@ -2448,6 +2499,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2479,6 +2531,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="true"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-open"
             draggable="false"
             role="treeitem"
@@ -2510,6 +2563,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2544,6 +2598,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2578,6 +2633,7 @@ exports[`Tree Props treeData 1`] = `
           </div>
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"
@@ -2654,6 +2710,7 @@ exports[`Tree Props treeData 2`] = `
         >
           <div
             aria-expanded="false"
+            aria-selected="false"
             class="rc-tree-treenode rc-tree-treenode-switcher-close rc-tree-treenode-leaf-last rc-tree-treenode-leaf"
             draggable="false"
             role="treeitem"


### PR DESCRIPTION
Our team welcomed the latest changes to improve accessibility in Tree component.
As we rely heavily on a11y for our tests (using testing-library), we found some problems with the current state:
* aria-selected was set when the node was _selectable_ not when the node was actually _selected_.
* aria-checked is supported not only on the checkbox, but on the whole treeitem as well (cf. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/treeitem_role)
* The aria-label for checkable tree items was "Select <title> <title>" because the tree item contains both, the checkbox (which has a good label) and the title itself, hence the double title in the tree items label.

This PR fixes all three problems and makes the tree component even better when used with assistive technology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持通过属性传递多选能力，从树组件传递到节点列表组件，并在相应元素上添加多选相关的 ARIA 属性，提升可访问性。

* **无障碍改进**
  * 树节点标题现在具有关联的无障碍标识符，增强屏幕阅读器的可读性。
  * ARIA 相关属性（如 aria-selected、aria-checked）根据节点的实际状态动态添加，提升语义准确性。

* **测试**
  * 更新了对 aria-selected 属性的测试断言，以反映无障碍属性行为的调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->