### PR TITLE
perf: uninstall classnames, install clsx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage/
 *.pyc
 *.pyo
 package-lock.json
+pnpm-lock.yaml
 .build
 node_modules
 .cache

--- a/docs/examples/icon.jsx
+++ b/docs/examples/icon.jsx
@@ -1,13 +1,13 @@
 /* eslint no-console:0 */
 /* eslint no-alert:0 */
 import React from 'react';
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import Tree, { TreeNode } from '@rc-component/tree';
 import '../../assets/index.less';
 import './icon.less';
 
 const Icon = ({ selected }) => (
-  <span className={classNames('customize-icon', selected && 'selected-icon')} />
+  <span className={clsx('customize-icon', selected && 'selected-icon')} />
 );
 
 const Demo = () => (

--- a/package.json
+++ b/package.json
@@ -45,12 +45,18 @@
   "lint-staged": {
     "*": "prettier --write --ignore-unknown"
   },
-  "peerDependencies": {
-    "react": "*",
-    "react-dom": "*"
+  "dependencies": {
+    "@rc-component/motion": "^1.0.0",
+    "@rc-component/util": "^1.2.1",
+    "clsx": "^2.1.1",
+    "rc-virtual-list": "^3.5.1"
   },
   "devDependencies": {
+    "@rc-component/dialog": "^1.0.0",
     "@rc-component/father-plugin": "^2.0.3",
+    "@rc-component/np": "^1.0.0",
+    "@rc-component/tooltip": "^1.0.0",
+    "@rc-component/trigger": "^3.0.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^30.0.0",
@@ -69,20 +75,14 @@
     "husky": "^9.1.6",
     "less": "^4.2.1",
     "lint-staged": "^16.1.2",
-    "@rc-component/np": "^1.0.0",
     "prettier": "^3.3.3",
-    "@rc-component/dialog": "^1.0.0",
     "rc-test": "^7.0.15",
-    "@rc-component/tooltip": "^1.0.0",
-    "@rc-component/trigger": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.3.3"
   },
-  "dependencies": {
-    "classnames": "2.x",
-    "@rc-component/motion": "^1.0.0",
-    "@rc-component/util": "^1.2.1",
-    "rc-virtual-list": "^3.5.1"
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   }
 }

--- a/src/Indent.tsx
+++ b/src/Indent.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import * as React from 'react';
 
 interface IndentProps {
@@ -15,7 +15,7 @@ const Indent: React.FC<IndentProps> = ({ prefixCls, level, isStart, isEnd }) => 
     list.push(
       <span
         key={i}
-        className={classNames(baseClassName, {
+        className={clsx(baseClassName, {
           [`${baseClassName}-start`]: isStart[i],
           [`${baseClassName}-end`]: isEnd[i],
         })}

--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import CSSMotion from '@rc-component/motion';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
 import * as React from 'react';
@@ -84,7 +84,7 @@ const MotionTreeNode = React.forwardRef<HTMLDivElement, MotionTreeNodeProps>((or
         {({ className: motionClassName, style: motionStyle }, motionRef) => (
           <div
             ref={motionRef}
-            className={classNames(`${prefixCls}-treenode-motion`, motionClassName)}
+            className={clsx(`${prefixCls}-treenode-motion`, motionClassName)}
             style={motionStyle}
           >
             {motionNodes.map(treeNode => {

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1,7 +1,7 @@
 // TODO: https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/treeview/treeview-2/treeview-2a.html
 // Fully accessibility support
 
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import warning from '@rc-component/util/lib/warning';
@@ -1459,7 +1459,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     return (
       <TreeContext.Provider value={contextValue}>
         <div
-          className={classNames(prefixCls, className, rootClassName, {
+          className={clsx(prefixCls, className, rootClassName, {
             [`${prefixCls}-show-line`]: showLine,
             [`${prefixCls}-focused`]: focused,
             [`${prefixCls}-active-focused`]: activeKey !== null,

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import classNames from 'classnames';
+import { clsx } from 'clsx';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import { TreeContext, UnstableContext } from './contextTypes';
 import Indent from './Indent';
@@ -228,10 +228,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       const switcherIconDom = renderSwitcherIconDom(true);
       return switcherIconDom !== false ? (
         <span
-          className={classNames(
-            `${context.prefixCls}-switcher`,
-            `${context.prefixCls}-switcher-noop`,
-          )}
+          className={clsx(`${context.prefixCls}-switcher`, `${context.prefixCls}-switcher-noop`)}
         >
           {switcherIconDom}
         </span>
@@ -241,7 +238,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
     return switcherIconDom !== false ? (
       <span
         onClick={onExpand}
-        className={classNames(
+        className={clsx(
           `${context.prefixCls}-switcher`,
           `${context.prefixCls}-switcher_${expanded ? ICON_OPEN : ICON_CLOSE}`,
         )}
@@ -262,7 +259,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
 
     return (
       <span
-        className={classNames(`${context.prefixCls}-checkbox`, {
+        className={clsx(`${context.prefixCls}-checkbox`, {
           [`${context.prefixCls}-checkbox-checked`]: checked,
           [`${context.prefixCls}-checkbox-indeterminate`]: !checked && halfChecked,
           [`${context.prefixCls}-checkbox-disabled`]: isDisabled || props.disableCheckbox,
@@ -290,7 +287,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
   const iconNode = React.useMemo<React.ReactNode>(() => {
     return (
       <span
-        className={classNames(
+        className={clsx(
           treeClassNames?.itemIcon,
           `${context.prefixCls}-iconEle`,
           `${context.prefixCls}-icon__${nodeState || 'docu'}`,
@@ -341,7 +338,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
 
       $icon = currentIcon ? (
         <span
-          className={classNames(
+          className={clsx(
             treeClassNames?.itemIcon,
             `${context.prefixCls}-iconEle`,
             `${context.prefixCls}-icon__customize`,
@@ -371,7 +368,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       <span
         ref={selectHandleRef}
         title={typeof title === 'string' ? title : ''}
-        className={classNames(wrapClass, `${wrapClass}-${nodeState || 'normal'}`, {
+        className={clsx(wrapClass, `${wrapClass}-${nodeState || 'normal'}`, {
           [`${context.prefixCls}-node-selected`]: !isDisabled && (selected || dragNodeHighlight),
         })}
         onMouseEnter={onMouseEnter}
@@ -382,7 +379,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       >
         {$icon}
         <span
-          className={classNames(`${context.prefixCls}-title`, treeClassNames?.itemTitle)}
+          className={clsx(`${context.prefixCls}-title`, treeClassNames?.itemTitle)}
           style={styles?.itemTitle}
         >
           {titleNode}
@@ -421,7 +418,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       ref={domRef}
       role="treeitem"
       aria-expanded={isLeaf ? undefined : expanded}
-      className={classNames(className, `${context.prefixCls}-treenode`, treeClassNames?.item, {
+      className={clsx(className, `${context.prefixCls}-treenode`, treeClassNames?.item, {
         [`${context.prefixCls}-treenode-disabled`]: isDisabled,
         [`${context.prefixCls}-treenode-switcher-${expanded ? 'open' : 'close'}`]: !isLeaf,
         [`${context.prefixCls}-treenode-checkbox-checked`]: checked,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 重构
  - 将组件（Tree、TreeNode、Indent、MotionTreeNode）与示例的 classnames 全面替换为 clsx，类名合成行为保持一致，无功能变化。
- 文档
  - 更新示例代码以采用 clsx 用法。
- 杂务
  - .gitignore 新增忽略 pnpm-lock.yaml。
  - 调整依赖分组：新增部分运行时依赖与开发依赖，保留 React/ReactDOM 作为对等依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->