### PR TITLE
feat: add itemSwitcher semantic DOM support

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -83,7 +83,7 @@ export type DraggableConfig = {
 
 export type ExpandAction = false | 'click' | 'doubleClick';
 
-export type SemanticName = 'itemIcon' | 'item' | 'itemTitle';
+export type SemanticName = 'itemIcon' | 'item' | 'itemTitle' | 'itemSwitcher';
 export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
   prefixCls: string;
   className?: string;

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -225,7 +225,12 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
       const switcherIconDom = renderSwitcherIconDom(true);
       return switcherIconDom !== false ? (
         <span
-          className={clsx(`${context.prefixCls}-switcher`, `${context.prefixCls}-switcher-noop`)}
+          className={clsx(
+            `${context.prefixCls}-switcher`,
+            `${context.prefixCls}-switcher-noop`,
+            treeClassNames?.itemSwitcher,
+          )}
+          style={styles?.itemSwitcher}
         >
           {switcherIconDom}
         </span>
@@ -238,7 +243,9 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
         className={clsx(
           `${context.prefixCls}-switcher`,
           `${context.prefixCls}-switcher_${expanded ? ICON_OPEN : ICON_CLOSE}`,
+          treeClassNames?.itemSwitcher,
         )}
+        style={styles?.itemSwitcher}
       >
         {switcherIconDom}
       </span>

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1387,11 +1387,13 @@ describe('Tree Basic', () => {
       item: 'test-item',
       itemIcon: 'test-icon',
       itemTitle: 'test-title',
+      itemSwitcher: 'test-switcher',
     };
     const testStyles = {
       item: { background: 'red' },
       itemIcon: { color: 'blue' },
       itemTitle: { color: 'yellow' },
+      itemSwitcher: { width: '32px' },
     };
     const { container } = render(
       <Tree
@@ -1404,12 +1406,15 @@ describe('Tree Basic', () => {
     const item = container.querySelector(`.${testClassNames.item}`);
     const icon = container.querySelector('.rc-tree-iconEle');
     const title = container.querySelector('.rc-tree-title');
+    const switcher = container.querySelector('.rc-tree-switcher');
 
     expect(icon).toHaveStyle(testStyles.itemIcon);
     expect(icon).toHaveClass(testClassNames.itemIcon);
     expect(title).toHaveStyle(testStyles.itemTitle);
     expect(title).toHaveClass(testClassNames.itemTitle);
     expect(item).toHaveStyle(testStyles.item);
+    expect(switcher).toHaveStyle(testStyles.itemSwitcher);
+    expect(switcher).toHaveClass(testClassNames.itemSwitcher);
   });
 
   it('should not scroll to top when click node and tree is focused', () => {


### PR DESCRIPTION
## Summary

- 新增 `itemSwitcher` 语义化 DOM 支持，`SemanticName` 类型中增加 `'itemSwitcher'`
- 在 `TreeNode` 的 `renderSwitcher` 中，对叶子节点和可展开节点的 switcher `<span>` 均应用 `classNames.itemSwitcher` 和 `styles.itemSwitcher`
- 补充 `itemSwitcher` 的测试用例，与 `itemIcon`、`itemTitle` 对齐


关联缺陷 https://github.com/ant-design/ant-design/issues/57078 先别close；antd也需要处理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 树形组件的切换器元素现已支持自定义样式和类名配置，提供更灵活的外观定制能力。

* **测试**
  * 更新测试用例以验证切换器元素的渲染和样式应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->