### PR TITLE
fix: prevent scroll-to-top when context menu closes

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -86,7 +86,6 @@ interface NodeListProps<TreeDataType extends BasicDataNode> {
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
-  onMouseUp?: React.MouseEventHandler<HTMLDivElement>;
   onActiveChange: (key: Key) => void;
 
   onListChangeStart: () => void;
@@ -147,7 +146,6 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
     onFocus,
     onBlur,
     onMouseDown,
-    onMouseUp,
     onActiveChange,
 
     onListChangeStart,
@@ -297,7 +295,6 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
         onFocus={onFocus}
         onBlur={onBlur}
         onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
         onVisibleChange={originList => {
           // The best match is using `fullList` - `originList` = `restList`
           // and check the `restList` to see if has the MOTION_KEY node

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -119,7 +119,6 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
   titleRender?: (node: TreeDataType) => React.ReactNode;
   dropIndicatorRender?: (props: DropIndicatorProps) => React.ReactNode;
   onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
-  onMouseUp?: React.MouseEventHandler<HTMLDivElement>;
   onFocus?: React.FocusEventHandler<HTMLDivElement>;
   onBlur?: React.FocusEventHandler<HTMLDivElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
@@ -321,6 +320,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   componentDidMount(): void {
     this.destroyed = false;
     this.onUpdated();
+    window.addEventListener('mouseup', this.onGlobalMouseUp);
   }
 
   componentDidUpdate(): void {
@@ -341,6 +341,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   componentWillUnmount() {
     window.removeEventListener('dragend', this.onWindowDragEnd);
+    window.removeEventListener('mouseup', this.onGlobalMouseUp);
     this.destroyed = true;
   }
 
@@ -1073,10 +1074,8 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     onMouseDown?.(event);
   };
 
-  onMouseUp: React.MouseEventHandler<HTMLDivElement> = event => {
+  onGlobalMouseUp = () => {
     this.focusedByMouse = false;
-    const { onMouseUp } = this.props;
-    onMouseUp?.(event);
   };
 
   onFocus: React.FocusEventHandler<HTMLDivElement> = (...args) => {
@@ -1538,7 +1537,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
             activeItem={this.getActiveItem()}
             onFocus={this.onFocus}
             onMouseDown={this.onMouseDown}
-            onMouseUp={this.onMouseUp}
             onBlur={this.onBlur}
             onKeyDown={this.onKeyDown}
             onActiveChange={this.onActiveChange}

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -321,7 +321,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   componentDidMount(): void {
     this.destroyed = false;
     this.onUpdated();
-    window.addEventListener('mouseup', this.onGlobalMouseUp);
   }
 
   componentDidUpdate(): void {
@@ -342,7 +341,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   componentWillUnmount() {
     window.removeEventListener('dragend', this.onWindowDragEnd);
-    window.removeEventListener('mouseup', this.onGlobalMouseUp);
     this.destroyed = true;
   }
 
@@ -1073,10 +1071,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     this.focusedByMouse = true;
     const { onMouseDown } = this.props;
     onMouseDown?.(event);
-  };
-
-  onGlobalMouseUp = () => {
-    this.focusedByMouse = false;
   };
 
   onMouseUp: React.MouseEventHandler<HTMLDivElement> = event => {

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -321,6 +321,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   componentDidMount(): void {
     this.destroyed = false;
     this.onUpdated();
+    window.addEventListener('mouseup', this.onGlobalMouseUp);
   }
 
   componentDidUpdate(): void {
@@ -341,6 +342,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   componentWillUnmount() {
     window.removeEventListener('dragend', this.onWindowDragEnd);
+    window.removeEventListener('mouseup', this.onGlobalMouseUp);
     this.destroyed = true;
   }
 
@@ -1073,6 +1075,10 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     onMouseDown?.(event);
   };
 
+  onGlobalMouseUp = () => {
+    this.focusedByMouse = false;
+  };
+
   onMouseUp: React.MouseEventHandler<HTMLDivElement> = event => {
     this.focusedByMouse = false;
     const { onMouseUp } = this.props;
@@ -1099,7 +1105,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   };
 
   onBlur: React.FocusEventHandler<HTMLDivElement> = (...args) => {
-    this.focusedByMouse = false;
     const { onBlur } = this.props;
     this.onActiveChange(null);
 

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1438,4 +1438,32 @@ describe('Tree Basic', () => {
     expect(scrollToSpy).not.toHaveBeenCalled();
     scrollToSpy.mockRestore();
   });
+
+  it('should not scroll to top when context menu closes and tree regains focus', () => {
+    const data = Array.from({ length: 20 }, (_, i) => ({
+      key: String(i),
+      title: `Node ${i}`,
+    }));
+    const treeRef = React.createRef<any>();
+    const { container } = render(
+      <Tree ref={treeRef} treeData={data} height={100} itemHeight={20} />,
+    );
+    const treeContainer = container.querySelector('.rc-tree-list');
+    const scrollToSpy = jest.spyOn(treeRef.current, 'scrollTo');
+
+    // User right-clicks a tree node, opening a context menu
+    fireEvent.mouseDown(treeContainer);
+    fireEvent.focus(treeContainer);
+    fireEvent.mouseUp(treeContainer);
+
+    // User clicks a context menu item — the menu closes, causing the tree
+    // to briefly lose then regain focus (mouseDown → blur → focus → mouseUp)
+    fireEvent.mouseDown(treeContainer);
+    fireEvent.blur(treeContainer);
+    fireEvent.focus(treeContainer);
+    fireEvent.mouseUp(treeContainer);
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    scrollToSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Solution

- ref https://github.com/ant-design/ant-design/issues/57239#issuecomment-4066734382

上一次的修复方案中在 mousedown 里判定焦点来源，mouseup 中重置，并且 blur 中也会重置，也就是这个 blur 导致了问题。打了 log 分析了一下图中 case 的事件触发顺序：

<img width="1906" height="504" alt="image" src="https://github.com/user-attachments/assets/50164580-09a0-437a-bd5b-3b2e0451fd25" />

(1) onMouseDown  true    ← 右键按下，focusedByMouse = true
(2) onFocus      true    ← Tree 获得焦点，focusedByMouse 为 true → 跳过滚动 ✅
(3) onNodeContextMenu    ← Dropdown 打开
(4) onMouseUp    false   ← 右键释放，focusedByMouse = false
--- 用户此时点击菜单项 ---
(5) onMouseDown  true    ← Tree 收到 mousedown，focusedByMouse = true
(6) onBlur       false   ← Tree 失焦，focusedByMouse 被重置为 false ❌
(7) onFocus      false   ← Tree 重新获焦，focusedByMouse 为 false → 触发滚动 🐛
(8) onMouseUp    false
(9) selected ['8-3']     ← 节点被选中
(10) onBlur      false

既然是 blur 里的重置行为导致了与右键菜单的交互触发了滚动，那就去掉 blur 里的重置行为就好了（不记得当时为啥加上的 2333）。

## Before

![Clipboard-20260316-145230-059](https://github.com/user-attachments/assets/d2b947fb-cea6-4356-a437-2b8602260bb2)

## After

![Clipboard-20260316-151118-031](https://github.com/user-attachments/assets/f7b84cc6-a7f4-4740-9fe4-9f897f50daa6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了树组件的焦点与鼠标交互处理，避免在上下文菜单关闭并重新聚焦时发生不必要的滚动或误触发焦点恢复。

* **测试**
  * 新增测试用例，验证在关闭上下文菜单并重新聚焦时树的滚动行为保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->