### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
   },
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
-    "@rc-component/util": "^1.8.1",
-    "@rc-component/virtual-list": "^1.0.1",
+    "@rc-component/util": "^1.11.1",
+    "@rc-component/virtual-list": "^1.2.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@rc-component/dialog": "^1.0.0",
-    "@rc-component/father-plugin": "^2.0.3",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@rc-component/tooltip": "^1.0.0",
     "@rc-component/trigger": "^3.0.0",

--- a/src/MotionTreeNode.tsx
+++ b/src/MotionTreeNode.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import CSSMotion from '@rc-component/motion';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 import * as React from 'react';
 import { TreeContext } from './contextTypes';
 import type { FlattenNode, TreeNodeProps } from './interface';

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -2,8 +2,7 @@
  * Handle virtual list of the TreeNodes.
  */
 
-import { getId } from '@rc-component/util/lib/hooks/useId';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { getId, useId, useLayoutEffect } from '@rc-component/util';
 import VirtualList, { type ListRef } from '@rc-component/virtual-list';
 import * as React from 'react';
 import MotionTreeNode from './MotionTreeNode';
@@ -18,7 +17,6 @@ import type {
 } from './interface';
 import { findExpandedKeys, getExpandRange } from './utils/diffUtil';
 import { getKey, getTreeNodeProps } from './utils/treeUtil';
-import useId from '@rc-component/util/lib/hooks/useId';
 
 export const MOTION_KEY = `RC_TREE_MOTION_${Math.random()}`;
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -2,8 +2,7 @@
 // Reference: https://www.w3.org/WAI/ARIA/apg/patterns/treeview
 
 import { clsx } from 'clsx';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
-import warning from '@rc-component/util/lib/warning';
+import { pickAttrs, warning } from '@rc-component/util';
 import * as React from 'react';
 
 import type {

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { clsx } from 'clsx';
-import { getId } from '@rc-component/util/lib/hooks/useId';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { getId, pickAttrs } from '@rc-component/util';
 import { TreeContext, UnstableContext } from './contextTypes';
 import Indent from './Indent';
 import type { TreeNodeProps } from './interface';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import type {
   DataNode,
   EventDataNode,
   FieldDataNode,
-  GetCheckDisabled,
   TreeNodeProps,
 } from './interface';
 import { UnstableContext } from './contextTypes';
@@ -15,6 +14,6 @@ export { arrAdd, arrDel, conductExpandParent } from './util';
 export { conductCheck } from './utils/conductUtil';
 export { convertDataToEntities, convertTreeToData, fillFieldNames } from './utils/treeUtil';
 export { TreeNode, UnstableContext };
-export type { DataNode, EventDataNode, GetCheckDisabled };
+export type { DataNode, EventDataNode };
 export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
 export default Tree;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import Tree from './Tree';
 import TreeNode from './TreeNode';
-import type { TreeProps } from './Tree';
+import type { ExpandAction, TreeProps } from './Tree';
 import type {
   BasicDataNode,
   DataEntity,
   DataNode,
   EventDataNode,
   FieldDataNode,
+  FieldNames,
   GetCheckDisabled,
   IconType,
   Key,
@@ -14,7 +15,6 @@ import type {
   ScrollTo,
   TreeNodeProps,
 } from './interface';
-import type { ExpandAction } from './Tree';
 import { UnstableContext } from './contextTypes';
 
 export { arrAdd, arrDel, conductExpandParent } from './util';
@@ -28,6 +28,7 @@ export type {
   EventDataNode,
   ExpandAction,
   FieldDataNode,
+  FieldNames,
   GetCheckDisabled,
   IconType,
   Key,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,12 @@
 import Tree from './Tree';
 import TreeNode from './TreeNode';
-import type { ExpandAction, TreeProps } from './Tree';
+import type { TreeProps } from './Tree';
 import type {
   BasicDataNode,
-  DataEntity,
   DataNode,
   EventDataNode,
   FieldDataNode,
-  FieldNames,
   GetCheckDisabled,
-  IconType,
-  Key,
-  SafeKey,
-  ScrollTo,
   TreeNodeProps,
 } from './interface';
 import { UnstableContext } from './contextTypes';
@@ -21,20 +15,6 @@ export { arrAdd, arrDel, conductExpandParent } from './util';
 export { conductCheck } from './utils/conductUtil';
 export { convertDataToEntities, convertTreeToData, fillFieldNames } from './utils/treeUtil';
 export { TreeNode, UnstableContext };
-export type {
-  BasicDataNode,
-  DataEntity,
-  DataNode,
-  EventDataNode,
-  ExpandAction,
-  FieldDataNode,
-  FieldNames,
-  GetCheckDisabled,
-  IconType,
-  Key,
-  SafeKey,
-  ScrollTo,
-  TreeNodeProps,
-  TreeProps,
-};
+export type { DataNode, EventDataNode, GetCheckDisabled };
+export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
 export default Tree;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,39 @@
 import Tree from './Tree';
 import TreeNode from './TreeNode';
 import type { TreeProps } from './Tree';
-import type { TreeNodeProps, BasicDataNode, FieldDataNode } from './interface';
+import type {
+  BasicDataNode,
+  DataEntity,
+  DataNode,
+  EventDataNode,
+  FieldDataNode,
+  GetCheckDisabled,
+  IconType,
+  Key,
+  SafeKey,
+  ScrollTo,
+  TreeNodeProps,
+} from './interface';
+import type { ExpandAction } from './Tree';
 import { UnstableContext } from './contextTypes';
 
+export { arrAdd, arrDel, conductExpandParent } from './util';
+export { conductCheck } from './utils/conductUtil';
+export { convertDataToEntities, convertTreeToData, fillFieldNames } from './utils/treeUtil';
 export { TreeNode, UnstableContext };
-export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
+export type {
+  BasicDataNode,
+  DataEntity,
+  DataNode,
+  EventDataNode,
+  ExpandAction,
+  FieldDataNode,
+  GetCheckDisabled,
+  IconType,
+  Key,
+  SafeKey,
+  ScrollTo,
+  TreeNodeProps,
+  TreeProps,
+};
 export default Tree;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import type { ScrollTo } from '@rc-component/virtual-list';
 
-export type { ScrollTo } from '@rc-component/virtual-list/lib/List';
+export type { ScrollTo };
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
   eventKey?: Key; // Pass by parent `cloneElement`
   prefixCls?: string;
@@ -120,8 +121,10 @@ export interface Entity {
   children?: Entity[];
 }
 
-export interface DataEntity<TreeDataType extends BasicDataNode = DataNode>
-  extends Omit<Entity, 'node' | 'parent' | 'children'> {
+export interface DataEntity<TreeDataType extends BasicDataNode = DataNode> extends Omit<
+  Entity,
+  'node' | 'parent' | 'children'
+> {
   node: TreeDataType;
   nodes: TreeDataType[];
   parent?: DataEntity<TreeDataType>;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import type { ScrollTo } from '@rc-component/virtual-list';
 
-export type { ScrollTo };
+export type { ScrollTo } from '@rc-component/virtual-list';
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
   eventKey?: Key; // Pass by parent `cloneElement`
   prefixCls?: string;

--- a/src/useUnmount.ts
+++ b/src/useUnmount.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 
 /**
  * Trigger only when component unmount

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -3,7 +3,7 @@
  * Legacy code. Should avoid to use if you are new to import these code.
  */
 
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import React from 'react';
 import type {
   BasicDataNode,

--- a/src/utils/conductUtil.ts
+++ b/src/utils/conductUtil.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type {
   BasicDataNode,
   DataEntity,

--- a/src/utils/treeUtil.ts
+++ b/src/utils/treeUtil.ts
@@ -1,6 +1,4 @@
-import toArray from '@rc-component/util/lib/Children/toArray';
-import omit from '@rc-component/util/lib/omit';
-import warning from '@rc-component/util/lib/warning';
+import { omit, toArray, warning } from '@rc-component/util';
 import * as React from 'react';
 import type {
   BasicDataNode,

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -2,8 +2,7 @@
 react/no-unused-state, react/prop-types, no-return-assign */
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { resetWarned, spyElementPrototypes } from '@rc-component/util';
 import Tree, { TreeNode } from '../src';
 import { objectMatcher, spyConsole, spyError } from './util';
 import { UnstableContext } from '../src';

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp, no-console,
 react/no-unused-state, react/prop-types, no-return-assign */
 import { act, createEvent, fireEvent, render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Tree, { FieldDataNode, TreeNode, TreeProps } from '../src';
 import { spyConsole } from './util';

--- a/tests/TreeProps.spec.tsx
+++ b/tests/TreeProps.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef, react/no-multi-comp */
 import { act, fireEvent, render } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import React from 'react';
 import Tree, { FieldDataNode, TreeNode } from '../src';
 import { objectMatcher, spyConsole, spyError } from './util';

--- a/tests/__mocks__/rc-virtual-list.tsx
+++ b/tests/__mocks__/rc-virtual-list.tsx
@@ -1,3 +1,0 @@
-import List from '@rc-component/virtual-list/lib/mock';
-
-export default List;


### PR DESCRIPTION
## 变更内容

- 升级 @rc-component/father-plugin、@rc-component/util 和 @rc-component/virtual-list 版本。
- 将项目中对其他 rc 包 es/lib 构建产物的引用调整为包根入口。
- 补充 tree 根入口中下游需要使用的类型与工具导出。
- 删除不再需要的 virtual-list 深路径 mock。

## 验证

- npm run compile
- npm run lint
- npm test -- TreeVirtual.spec.tsx --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 升级若干依赖与开发依赖至更新版本。

* **Refactor**
  * 统一第三方工具导入源，移除对内部子路径的引用以简化维护。
  * 扩展并补全对外导出（包含若干值导出与类型导出），增强类型可用性且不改变外部 API 行为。

* **Tests**
  * 更新测试工具导入路径并移除不再需要的测试 mock，提升测试可维护性与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/tree/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->