### PR TITLE
perf: avoid redundant flattenTreeData when expandedKeys is controlled

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -590,9 +590,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           newExpandedKeys = arrAdd(expandedKeys, nodeProps.eventKey);
         }
 
-        if (!this.props.hasOwnProperty('expandedKeys')) {
-          this.setExpandedKeys(newExpandedKeys);
-        }
+        this.setExpandedKeys(newExpandedKeys);
 
         onExpand?.(newExpandedKeys, {
           node: convertNodePropsToEventData<TreeDataType>(nodeProps),
@@ -667,30 +665,26 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     // Update drag position
 
     if (this.dragNodeProps.eventKey === dropTargetKey && dropLevelOffset === 0) {
-      if (
-        !(
-          this.state.dropPosition === null &&
-          this.state.dropLevelOffset === null &&
-          this.state.dropTargetKey === null &&
-          this.state.dropContainerKey === null &&
-          this.state.dropTargetPos === null &&
-          this.state.dropAllowed === false &&
-          this.state.dragOverNodeKey === null
-        )
-      ) {
+      if (!(
+        this.state.dropPosition === null &&
+        this.state.dropLevelOffset === null &&
+        this.state.dropTargetKey === null &&
+        this.state.dropContainerKey === null &&
+        this.state.dropTargetPos === null &&
+        this.state.dropAllowed === false &&
+        this.state.dragOverNodeKey === null
+      )) {
         this.resetDragState();
       }
-    } else if (
-      !(
-        dropPosition === this.state.dropPosition &&
-        dropLevelOffset === this.state.dropLevelOffset &&
-        dropTargetKey === this.state.dropTargetKey &&
-        dropContainerKey === this.state.dropContainerKey &&
-        dropTargetPos === this.state.dropTargetPos &&
-        dropAllowed === this.state.dropAllowed &&
-        dragOverNodeKey === this.state.dragOverNodeKey
-      )
-    ) {
+    } else if (!(
+      dropPosition === this.state.dropPosition &&
+      dropLevelOffset === this.state.dropLevelOffset &&
+      dropTargetKey === this.state.dropTargetKey &&
+      dropContainerKey === this.state.dropContainerKey &&
+      dropTargetPos === this.state.dropTargetPos &&
+      dropAllowed === this.state.dropAllowed &&
+      dragOverNodeKey === this.state.dragOverNodeKey
+    )) {
       this.setState({
         dropPosition,
         dropLevelOffset,
@@ -1135,6 +1129,10 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   // =========================== Expanded ===========================
   /** Set uncontrolled `expandedKeys`. This will also auto update `flattenNodes`. */
   setExpandedKeys = (expandedKeys: Key[]) => {
+    // When `expandedKeys` is controlled, `setUncontrolledState` with `atomic` will be a no-op.
+    if (this.props.hasOwnProperty('expandedKeys')) {
+      return;
+    }
     const { treeData, fieldNames } = this.state;
     const flattenNodes = flattenTreeData<TreeDataType>(treeData, expandedKeys, fieldNames);
     this.setUncontrolledState({ expandedKeys, flattenNodes }, true);

--- a/tests/ExpandedKeys.spec.tsx
+++ b/tests/ExpandedKeys.spec.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import Tree from '../src';
+import { flattenTreeData } from '../src/utils/treeUtil';
+
+jest.mock('../src/utils/treeUtil', () => {
+  const origin = jest.requireActual('../src/utils/treeUtil');
+  return {
+    ...origin,
+    flattenTreeData: jest.fn(origin.flattenTreeData),
+  };
+});
+
+const treeData = [
+  {
+    key: '0-0',
+    title: 'parent',
+    children: [{ key: '0-0-0', title: 'child' }],
+  },
+];
+
+describe('expandedKeys', () => {
+  const flattenMock = flattenTreeData as unknown as jest.Mock;
+
+  beforeEach(() => {
+    flattenMock.mockClear();
+  });
+
+  it('should not recompute flattenTreeData when expandedKeys is controlled', () => {
+    const onExpand = jest.fn();
+    const { container } = render(
+      <Tree treeData={treeData} expandedKeys={[]} onExpand={onExpand} />,
+    );
+
+    flattenMock.mockClear();
+
+    const switcher = container.querySelector('.rc-tree-switcher');
+    expect(switcher).not.toBeNull();
+    fireEvent.click(switcher as Element);
+
+    expect(onExpand).toHaveBeenCalledWith(['0-0'], expect.objectContaining({ expanded: true }));
+    expect(flattenMock).not.toHaveBeenCalled();
+  });
+
+  it('should recompute flattenTreeData in uncontrolled mode', () => {
+    const { container } = render(<Tree treeData={treeData} />);
+
+    flattenMock.mockClear();
+
+    const switcher = container.querySelector('.rc-tree-switcher');
+    expect(switcher).not.toBeNull();
+    fireEvent.click(switcher as Element);
+
+    expect(flattenMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 问题背景
当 `expandedKeys` 为受控属性时，`setExpandedKeys` 内部调用的 `setUncontrolledState` 处于 atomic 模式，实际是一个 no-op， 它通过 `flattenTreeData` 算出来的 `flattenNodes` 会被立即丢弃。也就是说，每次展开 / 收起节点，都会对整棵树做一次扁平化遍历，而结果根本没被用到。

## 改动
- `setExpandedKeys`：受控时提前 `return`，跳过多余的 `flattenTreeData` 调用。
- `onDragEnter`：移除重复的 `hasOwnProperty('expandedKeys')` 。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复树形组件在受控模式下展开/收起节点时，可能重复触发平铺数据计算的问题，提升性能与一致性。
  * 优化节点拖拽过程中的延迟展开与拖拽状态重置判断，减少状态异常。
* **Tests**
  * 新增 `ExpandedKeys` 相关测试用例：验证受控与非受控模式下展开行为及平铺数据函数调用差异。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->