### PR TITLE
feat: support auto-expanding ancestors in Tree `scrollTo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then open `http://localhost:8000`.
 | showLine | whether show line | bool | false |
 | treeData | treeNodes data Array, if set it then you need not to construct children TreeNode. (value should be unique across the whole array) | array<{key,title,children, [disabled, selectable]}> | - |
 | onCheck | click the treeNode/checkbox to fire | function(checkedKeys, e:{checked: bool, checkedNodes, node, event, nativeEvent}) | - |
-| onExpand | fire on treeNode expand or not | function(expandedKeys, {expanded: bool, node, nativeEvent}) | - |
+| onExpand | fire on treeNode expand or not | function(expandedKeys, {expanded: bool, node, nativeEvent?}) | - |
 | onDragEnd | it execs when fire the tree's dragend event | function({event,node}) | - |
 | onDragEnter | it execs when fire the tree's dragenter event | function({event,node,expandedKeys}) | - |
 | onDragLeave | it execs when fire the tree's dragleave event | function({event,node}) | - |
@@ -107,6 +107,37 @@ Then open `http://localhost:8000`.
 | dropIndicatorRender | The indicator to render when dragging | ({ dropPosition, dropLevelOffset, indent: number, prefixCls }) => ReactNode | - |
 | direction | Display direction of the tree, it may affect dragging behavior | `ltr` \| `rtl` | - |
 | expandAction | Tree open logic, optional: false \| `click` \| `doubleClick` | string \| boolean | `click` |
+
+### Tree methods
+
+| name | description | type | default |
+| --- | --- | --- | --- |
+| getExpandedKeys | Return a new array containing the current expanded keys plus every ancestor of `key`. Existing key order is preserved and missing ancestors are appended from the root to the direct parent. The target key itself is not added. | `(key: Key) => Key[]` | - |
+| scrollTo | Scroll to an offset, position, index, or node. Key-based scrolling also accepts `autoExpand` to expand hidden ancestors first. | `TreeScrollTo` | - |
+
+`TreeScrollTo` accepts the existing virtual-list scroll arguments (`number`, `null`, a `{ left?, top? }` position, or an index/key target) and the following key target:
+
+```ts
+interface TreeKeyScrollConfig {
+  key: React.Key;
+  align?: 'top' | 'bottom' | 'auto';
+  offset?: ScrollOffset;
+  autoExpand?: boolean;
+}
+```
+
+`ScrollOffset` is either a number or a function that returns a number from the resolved scroll alignment and item-size information.
+
+#### Auto-expand scrolling
+
+`scrollTo({ key, autoExpand: true })` is opt-in; `autoExpand` defaults to `false`.
+
+- In an uncontrolled Tree, missing ancestors are expanded from the root to the target's direct parent. The target itself is not expanded, existing expanded keys are preserved, and disabled ancestors can still be expanded.
+- Each newly expanded ancestor synchronously triggers one `onExpand` callback in root-to-parent order. Every callback receives the cumulative expanded keys, `info.expanded: true`, and `info.nativeEvent: undefined`.
+- Scrolling waits until expansion motion finishes and the target is present in the rendered list.
+- The target must already exist in `treeData`. Auto-expand scrolling does not call `loadData`; a missing target is a no-op, and a pending scroll is discarded if its target is removed before scrolling.
+- Multiple pending calls preserve expansion from earlier calls, but only the latest target is scrolled to. A pending scroll is discarded when the Tree unmounts.
+- A controlled Tree never changes `expandedKeys`. If ancestors are missing, the call is a no-op and emits a development warning. Use `getExpandedKeys(key)` to calculate the next controlled value, update `expandedKeys`, and call `scrollTo({ key, autoExpand: true })` again after the updated props render.
 
 ### TreeNode props
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -89,7 +89,7 @@ npm start
 | showLine | 是否显示连接线 | boolean | false |
 | treeData | 树节点数据数组。设置后无需手动构造子 TreeNode。（value 在整个数组中应唯一） | array<{key,title,children, [disabled, selectable]}> | - |
 | onCheck | 单击树节点/复选框时触发 | function(checkedKeys, e:{checked: boolean, checkedNodes, node, event, nativeEvent}) | - |
-| onExpand | 树节点展开或收起时触发 | function(expandedKeys, {expanded: boolean, node, nativeEvent}) | - |
+| onExpand | 树节点展开或收起时触发 | function(expandedKeys, {expanded: boolean, node, nativeEvent?}) | - |
 | onDragEnd | 触发树节点拖拽结束事件时执行 | function({event,node}) | - |
 | onDragEnter | 触发树节点拖拽进入事件时执行 | function({event,node,expandedKeys}) | - |
 | onDragLeave | 触发树节点拖拽离开事件时执行 | function({event,node}) | - |
@@ -107,6 +107,37 @@ npm start
 | dropIndicatorRender | 拖动时要渲染的指示器 | ({ dropPosition, dropLevelOffset, indent: number, prefixCls }) => ReactNode | - |
 | direction | 树的显示方向，可能会影响拖动行为 | `ltr` \| `rtl` | - |
 | expandAction | 树打开逻辑，可选：`false` 或 `click` | string \| boolean | `click` |
+
+### Tree 方法
+
+| 方法 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| getExpandedKeys | 返回一个新数组，其中包含当前展开节点及 `key` 的所有祖先节点。保留已有 key 的顺序，并按根节点到直接父节点的顺序追加缺失祖先；不会主动加入目标节点本身。 | `(key: Key) => Key[]` | - |
+| scrollTo | 滚动到指定偏移、位置、索引或节点。基于 key 滚动时还可通过 `autoExpand` 先展开隐藏的祖先节点。 | `TreeScrollTo` | - |
+
+`TreeScrollTo` 支持已有的虚拟列表滚动参数（`number`、`null`、`{ left?, top? }` 位置或基于索引/key 的目标），并新增以下 key 目标配置：
+
+```ts
+interface TreeKeyScrollConfig {
+  key: React.Key;
+  align?: 'top' | 'bottom' | 'auto';
+  offset?: ScrollOffset;
+  autoExpand?: boolean;
+}
+```
+
+`ScrollOffset` 可以是数字，也可以是一个函数；该函数根据最终滚动对齐方式和节点尺寸信息返回偏移量。
+
+#### 自动展开并滚动
+
+`scrollTo({ key, autoExpand: true })` 是显式开启的能力；`autoExpand` 默认为 `false`。
+
+- 非受控 Tree 会按根节点到目标节点直接父节点的顺序展开缺失祖先。目标节点本身不会被展开，已有展开状态会被保留，禁用的祖先节点也可以被展开。
+- 每个新展开的祖先节点都会按根节点到直接父节点的顺序同步触发一次 `onExpand`。每次回调收到累积的展开 key、`info.expanded: true`，以及 `info.nativeEvent: undefined`。
+- 滚动会等待展开动画结束，并确认目标节点已进入渲染列表后再执行。
+- 目标节点必须已经存在于 `treeData` 中。自动展开不会调用 `loadData`；找不到目标节点时不执行任何操作，如果目标节点在滚动前被移除，则丢弃待执行的滚动。
+- 连续调用会保留先前调用产生的展开状态，但只滚动到最后一次调用的目标；Tree 卸载时会丢弃尚未执行的滚动。
+- 受控 Tree 不会修改 `expandedKeys`。祖先节点尚未展开时，本次调用不执行滚动，并在开发环境输出警告。应先通过 `getExpandedKeys(key)` 计算新的受控值，更新 `expandedKeys`，待新属性完成渲染后再次调用 `scrollTo({ key, autoExpand: true })`。
 
 ### TreeNode props
 

--- a/docs/demo/scroll-to-auto-expand.md
+++ b/docs/demo/scroll-to-auto-expand.md
@@ -1,0 +1,10 @@
+---
+title: Scroll to a hidden node
+nav:
+  title: Demo
+  path: /demo
+---
+
+Use `getExpandedKeys` to update a controlled Tree, then call `scrollTo` with `autoExpand` after the new expanded state renders.
+
+<code src="../examples/scroll-to-auto-expand.jsx"></code>

--- a/docs/examples/scroll-to-auto-expand.jsx
+++ b/docs/examples/scroll-to-auto-expand.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from 'react';
+import '../../assets/index.less';
+import Tree from '@rc-component/tree';
+
+const targetKey = 'documents/reports/2026/annual';
+const treeData = [
+  {
+    key: 'documents',
+    title: 'Documents',
+    children: [
+      {
+        key: 'documents/reports',
+        title: 'Reports',
+        children: [
+          {
+            key: 'documents/reports/2026',
+            title: '2026',
+            children: [
+              { key: 'documents/reports/2026/january', title: 'January' },
+              { key: 'documents/reports/2026/february', title: 'February' },
+              { key: 'documents/reports/2026/march', title: 'March' },
+              { key: 'documents/reports/2026/april', title: 'April' },
+              { key: 'documents/reports/2026/may', title: 'May' },
+              { key: 'documents/reports/2026/june', title: 'June' },
+              { key: 'documents/reports/2026/july', title: 'July' },
+              { key: 'documents/reports/2026/august', title: 'August' },
+              { key: 'documents/reports/2026/september', title: 'September' },
+              { key: 'documents/reports/2026/october', title: 'October' },
+              { key: 'documents/reports/2026/november', title: 'November' },
+              { key: targetKey, title: 'Annual report' },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export default function Demo() {
+  const treeRef = useRef(null);
+  const pendingScrollKeyRef = useRef();
+  const [expandedKeys, setExpandedKeys] = useState([]);
+
+  useEffect(() => {
+    const key = pendingScrollKeyRef.current;
+
+    if (key !== undefined) {
+      pendingScrollKeyRef.current = undefined;
+      treeRef.current?.scrollTo({
+        key,
+        align: 'top',
+        autoExpand: true,
+      });
+    }
+  }, [expandedKeys]);
+
+  const scrollToAnnualReport = () => {
+    pendingScrollKeyRef.current = targetKey;
+    setExpandedKeys(treeRef.current.getExpandedKeys(targetKey));
+  };
+
+  return (
+    <>
+      <button type="button" onClick={scrollToAnnualReport}>
+        Scroll to annual report
+      </button>
+      <Tree
+        ref={treeRef}
+        height={160}
+        itemHeight={28}
+        expandedKeys={expandedKeys}
+        onExpand={setExpandedKeys}
+        treeData={treeData}
+      />
+    </>
+  );
+}

--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -48,6 +48,7 @@ const MotionFlattenData: FlattenNode = {
 export interface NodeListRef {
   scrollTo: ScrollTo;
   getIndentWidth: () => number;
+  isKeyInList: (key: Key) => boolean;
 }
 
 interface NodeListProps<TreeDataType extends BasicDataNode> {
@@ -159,12 +160,18 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   // =============================== Ref ================================
   const listRef = React.useRef<ListRef>(null);
   const indentMeasurerRef = React.useRef<HTMLDivElement>(null);
-  React.useImperativeHandle(ref, () => ({
-    scrollTo: scroll => {
-      listRef.current.scrollTo(scroll);
-    },
-    getIndentWidth: () => indentMeasurerRef.current.offsetWidth,
-  }));
+  const mergedDataRef = React.useRef<FlattenNode[]>(data);
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      scrollTo: scroll => {
+        listRef.current.scrollTo(scroll);
+      },
+      getIndentWidth: () => indentMeasurerRef.current.offsetWidth,
+      isKeyInList: key => mergedDataRef.current.some(item => item.key === key),
+    }),
+    [],
+  );
 
   // ============================== Motion ==============================
   const [prevExpandedKeys, setPrevExpandedKeys] = React.useState(expandedKeys);
@@ -244,6 +251,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   }, [dragging]);
 
   const mergedData = motion ? transitionData : data;
+  mergedDataRef.current = mergedData;
 
   const treeNodeRequiredProps = {
     expandedKeys,

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -26,7 +26,8 @@ import type {
   Key,
   KeyEntities,
   SafeKey,
-  ScrollTo,
+  TreeKeyScrollConfig,
+  TreeScrollTo,
   TreeNodeProps,
 } from './interface';
 import NodeList, { MOTION_KEY, MotionEntity, type NodeListRef } from './NodeList';
@@ -38,6 +39,7 @@ import {
   calcSelectedKeys,
   conductExpandParent,
   getDragChildrenKeys,
+  getAncestorKeys,
   parseCheckedKeys,
   posToArr,
 } from './util';
@@ -134,7 +136,7 @@ export interface TreeProps<TreeDataType extends BasicDataNode = DataNode> {
     info: {
       node: EventDataNode<TreeDataType>;
       expanded: boolean;
-      nativeEvent: MouseEvent;
+      nativeEvent?: MouseEvent;
     },
   ) => void;
   onCheck?: (
@@ -269,6 +271,10 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   loadingRetryTimes: Record<SafeKey, number> = {};
 
+  pendingExpandedKeys: Key[] | null = null;
+
+  pendingScroll: TreeKeyScrollConfig | null = null;
+
   state: TreeState<TreeDataType> = {
     keyEntities: {},
 
@@ -333,6 +339,14 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   onUpdated() {
     const { activeKey, itemScrollOffset = 0 } = this.props;
 
+    if (this.pendingExpandedKeys === this.state.expandedKeys) {
+      this.pendingExpandedKeys = null;
+    }
+
+    if (this.pendingScroll) {
+      this.flushPendingScroll();
+    }
+
     if (activeKey !== undefined && activeKey !== this.state.activeKey) {
       this.setState({ activeKey });
 
@@ -343,6 +357,8 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   }
 
   componentWillUnmount() {
+    this.clearPendingScroll();
+    this.pendingExpandedKeys = null;
     window.removeEventListener('dragend', this.onWindowDragEnd);
     window.removeEventListener('mouseup', this.onGlobalMouseUp);
     this.destroyed = true;
@@ -1126,6 +1142,35 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     };
   };
 
+  getExpandedKeys = (key: Key): Key[] => {
+    const baseKeys = this.pendingExpandedKeys ?? this.state.expandedKeys;
+    const ancestorKeys = getAncestorKeys(key, this.state.keyEntities);
+    const nextKeys = [...baseKeys];
+    const keySet = new Set(nextKeys);
+
+    ancestorKeys.forEach(ancestorKey => {
+      if (!keySet.has(ancestorKey)) {
+        keySet.add(ancestorKey);
+        nextKeys.push(ancestorKey);
+      }
+    });
+
+    return nextKeys;
+  };
+
+  getEventData = (key: Key, expandedKeys: Key[]): EventDataNode<TreeDataType> => {
+    const entity = getEntity(this.state.keyEntities, key);
+    const requiredProps = {
+      ...this.getTreeNodeRequiredProps(),
+      expandedKeys,
+    };
+
+    return convertNodePropsToEventData<TreeDataType>({
+      ...getTreeNodeProps(key, requiredProps),
+      data: entity.node,
+    });
+  };
+
   // =========================== Expanded ===========================
   /** Set uncontrolled `expandedKeys`. This will also auto update `flattenNodes`. */
   setExpandedKeys = (expandedKeys: Key[]) => {
@@ -1203,6 +1248,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       this.setUncontrolledState({
         listChanging: false,
       });
+      this.flushPendingScroll();
     });
   };
 
@@ -1402,8 +1448,90 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     }
   };
 
-  scrollTo: ScrollTo = scroll => {
-    this.listRef.current.scrollTo(scroll);
+  clearPendingScroll = () => {
+    this.pendingScroll = null;
+  };
+
+  flushPendingScroll = () => {
+    const pendingScroll = this.pendingScroll;
+
+    if (!pendingScroll) {
+      return;
+    }
+
+    if (!getEntity(this.state.keyEntities, pendingScroll.key)) {
+      this.pendingScroll = null;
+      return;
+    }
+
+    if (this.listRef.current?.isKeyInList(pendingScroll.key)) {
+      this.pendingScroll = null;
+      this.listRef.current.scrollTo(pendingScroll);
+    }
+  };
+
+  scrollTo: TreeScrollTo = scroll => {
+    this.clearPendingScroll();
+
+    if (!scroll || typeof scroll !== 'object' || !('key' in scroll)) {
+      this.listRef.current.scrollTo(scroll);
+      return;
+    }
+
+    const { autoExpand, ...scrollConfig } = scroll as TreeKeyScrollConfig;
+
+    if (!autoExpand) {
+      this.listRef.current.scrollTo(scrollConfig);
+      return;
+    }
+
+    const { key } = scrollConfig;
+    const { expandedKeys, keyEntities } = this.state;
+    const entity = getEntity(keyEntities, key);
+
+    if (!entity) {
+      return;
+    }
+
+    const baseKeys = this.pendingExpandedKeys ?? expandedKeys;
+    const baseKeySet = new Set(baseKeys);
+    const ancestorKeys = getAncestorKeys(key, keyEntities);
+    const missingAncestorKeys = ancestorKeys.filter(ancestorKey => !baseKeySet.has(ancestorKey));
+
+    if (!missingAncestorKeys.length) {
+      if (this.listRef.current.isKeyInList(key)) {
+        this.listRef.current.scrollTo(scrollConfig);
+      } else {
+        this.pendingScroll = scrollConfig;
+      }
+      return;
+    }
+
+    if (this.props.hasOwnProperty('expandedKeys')) {
+      warning(
+        false,
+        '`scrollTo` with `autoExpand` cannot update controlled `expandedKeys`. ' +
+          'Call `getExpandedKeys` and update `expandedKeys` before scrolling.',
+      );
+      return;
+    }
+
+    const nextExpandedKeys = this.getExpandedKeys(key);
+    this.pendingExpandedKeys = nextExpandedKeys;
+    this.pendingScroll = scrollConfig;
+    this.setExpandedKeys(nextExpandedKeys);
+
+    const { onExpand } = this.props;
+    let callbackExpandedKeys = [...baseKeys];
+
+    missingAncestorKeys.forEach(ancestorKey => {
+      callbackExpandedKeys = arrAdd(callbackExpandedKeys, ancestorKey);
+      onExpand?.(callbackExpandedKeys, {
+        node: this.getEventData(ancestorKey, callbackExpandedKeys),
+        expanded: true,
+        nativeEvent: undefined,
+      });
+    });
   };
 
   render() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,9 @@ import type {
   DataNode,
   EventDataNode,
   FieldDataNode,
+  TreeKeyScrollConfig,
   TreeNodeProps,
+  TreeScrollTo,
 } from './interface';
 import { UnstableContext } from './contextTypes';
 
@@ -15,5 +17,12 @@ export { conductCheck } from './utils/conductUtil';
 export { convertDataToEntities, convertTreeToData, fillFieldNames } from './utils/treeUtil';
 export { TreeNode, UnstableContext };
 export type { DataNode, EventDataNode };
-export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
+export type {
+  TreeProps,
+  TreeNodeProps,
+  BasicDataNode,
+  FieldDataNode,
+  TreeKeyScrollConfig,
+  TreeScrollTo,
+};
 export default Tree;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { ScrollOffset, ScrollTo as VirtualListScrollTo } from '@rc-component/virtual-list';
 
 export type { ScrollTo } from '@rc-component/virtual-list';
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
@@ -61,6 +62,17 @@ export type FieldDataNode<T, ChildFieldName extends string = 'children'> = Basic
   Partial<Record<ChildFieldName, FieldDataNode<T, ChildFieldName>[]>>;
 
 export type Key = React.Key;
+
+export interface TreeKeyScrollConfig {
+  key: Key;
+  align?: 'top' | 'bottom' | 'auto';
+  offset?: ScrollOffset;
+  autoExpand?: boolean;
+}
+
+export type TreeScrollTo = (
+  scroll?: Parameters<VirtualListScrollTo>[0] | TreeKeyScrollConfig,
+) => void;
 
 /**
  * Typescript not support `bigint` as index type yet.

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -329,6 +329,18 @@ export function parseCheckedKeys(keys: Key[] | { checked: Key[]; halfChecked: Ke
   return keyProps;
 }
 
+export function getAncestorKeys(key: Key, keyEntities: KeyEntities): Key[] {
+  const keys: Key[] = [];
+  let entity = getEntity(keyEntities, key)?.parent;
+
+  while (entity) {
+    keys.push(entity.key);
+    entity = entity.parent;
+  }
+
+  return keys.reverse();
+}
+
 /**
  * If user use `autoExpandParent` we should get the list of parent node
  * @param keyList

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1063,6 +1063,348 @@ describe('Tree Basic', () => {
       expect(called).toBeTruthy();
       jest.useRealTimers();
     });
+
+    it('forwards non-key scroll config', () => {
+      const treeRef = React.createRef<any>();
+      render(<Tree ref={treeRef} />);
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      act(() => {
+        treeRef.current.scrollTo(24);
+        treeRef.current.scrollTo({ top: 12 });
+        treeRef.current.scrollTo(null);
+      });
+
+      expect(scrollToSpy.mock.calls).toEqual([[24], [{ top: 12 }], [null]]);
+    });
+  });
+
+  describe('getExpandedKeys', () => {
+    const treeData = [
+      { key: 'other' },
+      {
+        key: 'root',
+        children: [
+          {
+            key: 'folder',
+            children: [{ key: 'target' }],
+          },
+        ],
+      },
+    ];
+
+    it('preserves current keys and appends ancestors only', () => {
+      const treeRef = React.createRef<any>();
+      render(
+        <Tree
+          ref={treeRef}
+          defaultExpandParent={false}
+          defaultExpandedKeys={['other', 'target']}
+          treeData={treeData}
+        />,
+      );
+
+      const result = treeRef.current.getExpandedKeys('target');
+
+      expect(result).toEqual(['other', 'target', 'root', 'folder']);
+      expect(result).not.toBe(treeRef.current.state.expandedKeys);
+      expect(treeRef.current.state.expandedKeys).toEqual(['other', 'target']);
+    });
+
+    it('returns a copy for a missing target', () => {
+      const treeRef = React.createRef<any>();
+      render(
+        <Tree
+          ref={treeRef}
+          defaultExpandParent={false}
+          defaultExpandedKeys={['other']}
+          treeData={treeData}
+        />,
+      );
+
+      const result = treeRef.current.getExpandedKeys('missing');
+
+      expect(result).toEqual(['other']);
+      expect(result).not.toBe(treeRef.current.state.expandedKeys);
+    });
+
+    it('handles null controlled expandedKeys', () => {
+      const treeRef = React.createRef<any>();
+      render(<Tree ref={treeRef} expandedKeys={null as any} treeData={treeData} />);
+
+      expect(treeRef.current.getExpandedKeys('target')).toEqual(['root', 'folder']);
+    });
+
+    it('does not change controlled expansion or trigger onExpand', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(
+        <Tree ref={treeRef} expandedKeys={['other']} onExpand={onExpand} treeData={treeData} />,
+      );
+
+      expect(treeRef.current.getExpandedKeys('target')).toEqual(['other', 'root', 'folder']);
+      expect(treeRef.current.state.expandedKeys).toEqual(['other']);
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scrollTo autoExpand', () => {
+    const errorSpy = spyError();
+    const treeData = [
+      {
+        key: 'root',
+        title: 'Root',
+        children: [
+          {
+            key: 'folder',
+            title: 'Folder',
+            children: [
+              {
+                key: 'target',
+                title: 'Target',
+                children: [{ key: 'leaf', title: 'Leaf' }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    it('expands ancestors without expanding the target', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      const { queryByText } = render(
+        <Tree ref={treeRef} motion={null} onExpand={onExpand} treeData={treeData} />,
+      );
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      expect(queryByText('Target')).toBeNull();
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+      });
+
+      expect(queryByText('Target')).toBeTruthy();
+      expect(queryByText('Leaf')).toBeNull();
+      expect(treeRef.current.state.expandedKeys).toEqual(['root', 'folder']);
+      expect(onExpand.mock.calls.map(([keys]) => keys)).toEqual([['root'], ['root', 'folder']]);
+      expect(onExpand.mock.calls.map(([, info]) => info.node.key)).toEqual(['root', 'folder']);
+      expect(
+        onExpand.mock.calls.every(
+          ([, info]) => info.expanded === true && info.nativeEvent === undefined,
+        ),
+      ).toBe(true);
+      expect(scrollToSpy).toHaveBeenCalledWith({ key: 'target' });
+    });
+
+    it('only expands and reports missing ancestors', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(
+        <Tree
+          ref={treeRef}
+          motion={null}
+          defaultExpandedKeys={['root']}
+          onExpand={onExpand}
+          treeData={treeData}
+        />,
+      );
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual(['root', 'folder']);
+      expect(onExpand).toHaveBeenCalledTimes(1);
+      expect(onExpand).toHaveBeenCalledWith(
+        ['root', 'folder'],
+        expect.objectContaining({
+          expanded: true,
+          nativeEvent: undefined,
+          node: expect.objectContaining({ key: 'folder' }),
+        }),
+      );
+    });
+
+    it('expands disabled ancestors', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(
+        <Tree
+          ref={treeRef}
+          motion={null}
+          onExpand={onExpand}
+          treeData={[
+            {
+              key: 'disabled-root',
+              disabled: true,
+              children: [{ key: 'disabled-target' }],
+            },
+          ]}
+        />,
+      );
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'disabled-target', autoExpand: true });
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual(['disabled-root']);
+      expect(onExpand).toHaveBeenCalledWith(
+        ['disabled-root'],
+        expect.objectContaining({
+          expanded: true,
+          node: expect.objectContaining({ disabled: true, key: 'disabled-root' }),
+        }),
+      );
+    });
+
+    it('does nothing when the target does not exist', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      const loadData = jest.fn();
+      render(
+        <Tree
+          ref={treeRef}
+          motion={null}
+          onExpand={onExpand}
+          loadData={loadData}
+          treeData={treeData}
+        />,
+      );
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'missing', autoExpand: true });
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual([]);
+      expect(onExpand).not.toHaveBeenCalled();
+      expect(loadData).not.toHaveBeenCalled();
+    });
+
+    it('keeps auto expansion opt-in', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(<Tree ref={treeRef} motion={null} onExpand={onExpand} treeData={treeData} />);
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target' });
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual([]);
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
+    it('scrolls directly when the target needs no new ancestors', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(
+        <Tree
+          ref={treeRef}
+          motion={null}
+          defaultExpandedKeys={['root', 'folder']}
+          onExpand={onExpand}
+          treeData={treeData}
+        />,
+      );
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      act(() => {
+        treeRef.current.scrollTo({
+          key: 'target',
+          align: 'top',
+          offset: 8,
+          autoExpand: true,
+        });
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ key: 'target', align: 'top', offset: 8 });
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
+    it('scrolls to a root target without changing expansion', () => {
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(<Tree ref={treeRef} motion={null} onExpand={onExpand} treeData={treeData} />);
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'root', autoExpand: true });
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ key: 'root' });
+      expect(treeRef.current.state.expandedKeys).toEqual([]);
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
+    it('does not mutate controlled expandedKeys', () => {
+      resetWarned();
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      const renderTree = (expandedKeys: React.Key[]) => (
+        <Tree
+          ref={treeRef}
+          motion={null}
+          expandedKeys={expandedKeys}
+          onExpand={onExpand}
+          treeData={treeData}
+        />
+      );
+      const { rerender } = render(renderTree([]));
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual([]);
+      expect(onExpand).not.toHaveBeenCalled();
+      expect(scrollToSpy).not.toHaveBeenCalled();
+      expect(errorSpy()).toHaveBeenCalledWith(
+        'Warning: `scrollTo` with `autoExpand` cannot update controlled `expandedKeys`. ' +
+          'Call `getExpandedKeys` and update `expandedKeys` before scrolling.',
+      );
+
+      const nextExpandedKeys = treeRef.current.getExpandedKeys('target');
+      rerender(renderTree(nextExpandedKeys));
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+      });
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ key: 'target' });
+      expect(onExpand).not.toHaveBeenCalled();
+    });
+
+    it('keeps expanded paths and only scrolls to the latest target', () => {
+      jest.useFakeTimers();
+      const treeRef = React.createRef<any>();
+      const onExpand = jest.fn();
+      render(
+        <Tree
+          ref={treeRef}
+          motion={null}
+          onExpand={onExpand}
+          treeData={[
+            { key: 'root-a', children: [{ key: 'target-a' }] },
+            { key: 'root-b', children: [{ key: 'target-b' }] },
+          ]}
+        />,
+      );
+      const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'target-a', autoExpand: true });
+        treeRef.current.scrollTo({ key: 'target-b', autoExpand: true });
+        jest.runAllTimers();
+      });
+
+      expect(treeRef.current.state.expandedKeys).toEqual(['root-a', 'root-b']);
+      expect(onExpand.mock.calls.map(([keys]) => keys)).toEqual([['root-a'], ['root-a', 'root-b']]);
+      expect(scrollToSpy).toHaveBeenCalledTimes(1);
+      expect(scrollToSpy).toHaveBeenCalledWith({ key: 'target-b' });
+
+      jest.useRealTimers();
+    });
   });
 
   describe('offset should work', () => {

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -118,6 +118,176 @@ describe('Tree Motion', () => {
     expect(onExpand).not.toHaveBeenCalled();
   });
 
+  it('waits for expanded nodes to finish motion before scrolling', () => {
+    const treeRef = React.createRef<any>();
+    render(
+      <Tree
+        ref={treeRef}
+        height={100}
+        itemHeight={20}
+        motion={{
+          motionName: 'bamboo',
+          motionDeadline: 100,
+        }}
+        treeData={[
+          {
+            key: 'root',
+            children: [{ key: 'target' }],
+          },
+        ]}
+      />,
+    );
+    const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+    act(() => {
+      treeRef.current.scrollTo({
+        key: 'target',
+        align: 'top',
+        offset: 8,
+        autoExpand: true,
+      });
+    });
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(scrollToSpy).toHaveBeenCalledWith({
+      key: 'target',
+      align: 'top',
+      offset: 8,
+    });
+  });
+
+  it('waits for controlled expansion motion before scrolling', () => {
+    const treeRef = React.createRef<any>();
+    const renderTree = (expandedKeys: React.Key[]) => (
+      <Tree
+        ref={treeRef}
+        height={100}
+        itemHeight={20}
+        motion={{
+          motionName: 'bamboo',
+          motionDeadline: 100,
+        }}
+        expandedKeys={expandedKeys}
+        treeData={[
+          {
+            key: 'root',
+            children: [{ key: 'target' }],
+          },
+        ]}
+      />
+    );
+    const { rerender } = render(renderTree([]));
+    const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+    rerender(renderTree(treeRef.current.getExpandedKeys('target')));
+    act(() => {
+      treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+    });
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ key: 'target' });
+  });
+
+  it('does not scroll after unmounting with a pending target', () => {
+    const treeRef = React.createRef<any>();
+    const { unmount } = render(
+      <Tree
+        ref={treeRef}
+        height={100}
+        itemHeight={20}
+        motion={{
+          motionName: 'bamboo',
+          motionDeadline: 100,
+        }}
+        treeData={[
+          {
+            key: 'root',
+            children: [{ key: 'target' }],
+          },
+        ]}
+      />,
+    );
+    const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+    act(() => {
+      treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+    });
+    unmount();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending scroll when the target is removed', () => {
+    const treeRef = React.createRef<any>();
+    const treeData = [
+      {
+        key: 'root',
+        children: [{ key: 'target' }],
+      },
+    ];
+    const renderTree = (data: typeof treeData) => (
+      <Tree
+        ref={treeRef}
+        height={100}
+        itemHeight={20}
+        motion={{
+          motionName: 'bamboo',
+          motionDeadline: 100,
+        }}
+        treeData={data}
+      />
+    );
+    const { rerender } = render(renderTree(treeData));
+    const scrollToSpy = jest.spyOn(treeRef.current.listRef.current, 'scrollTo');
+
+    act(() => {
+      treeRef.current.scrollTo({ key: 'target', autoExpand: true });
+    });
+    rerender(renderTree([{ key: 'root', children: [] }]));
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    rerender(renderTree(treeData));
+    act(() => {
+      jest.runAllTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(scrollToSpy).not.toHaveBeenCalled();
+  });
+
   describe('MotionTreeNode should always trigger motion end', () => {
     it('with motionNodes', () => {
       const onMotionStart = jest.fn();

--- a/tests/type.spec.tsx
+++ b/tests/type.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, react/no-multi-comp */
 import React from 'react';
 import { render } from '@testing-library/react';
-import Tree, { BasicDataNode } from '../src';
+import Tree, { BasicDataNode, TreeKeyScrollConfig, TreeScrollTo } from '../src';
 
 describe('Tree.TypeScript', () => {
   it('fieldNames', () => {
@@ -25,5 +25,16 @@ describe('Tree.TypeScript', () => {
         }}
       />,
     );
+  });
+  it('scrollTo autoExpand', () => {
+    const config: TreeKeyScrollConfig = {
+      key: 'target',
+      align: 'auto',
+      offset: () => 8,
+      autoExpand: true,
+    };
+    const scrollTo: TreeScrollTo = () => {};
+
+    scrollTo(config);
   });
 });

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -4,6 +4,7 @@ import Tree, { TreeNode } from '../src';
 import {
   conductExpandParent,
   convertDataToTree,
+  getAncestorKeys,
   getDragChildrenKeys,
   parseCheckedKeys,
 } from '../src/util';
@@ -450,6 +451,25 @@ describe('Util', () => {
     const { keyEntities } = convertDataToEntities(convertTreeToData(tree.props.children));
     const keys = conductExpandParent(['good'], keyEntities);
     expect(keys.sort()).toEqual(['bamboo', 'is', 'good'].sort());
+  });
+
+  it('getAncestorKeys returns ancestors from root to direct parent', () => {
+    const { keyEntities } = convertDataToEntities([
+      {
+        key: 'root',
+        disabled: true,
+        children: [
+          {
+            key: 'folder',
+            children: [{ key: 'target' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(getAncestorKeys('target', keyEntities)).toEqual(['root', 'folder']);
+    expect(getAncestorKeys('root', keyEntities)).toEqual([]);
+    expect(getAncestorKeys('missing', keyEntities)).toEqual([]);
   });
 
   it('getDragChildrenKeys', () => {


### PR DESCRIPTION
## 关联 Issue

Related to ant-design/ant-design#58699

## 背景

Tree 的 `scrollTo({ key })` 只能定位已经出现在扁平渲染列表中的节点。当目标节点被折叠的祖先节点隐藏时，现有 API 无法滚动到该节点。

本 PR 为 key-based `scrollTo` 增加显式的自动展开能力，同时为受控 Tree 提供计算目标展开路径的方法。

## 方案

- 新增 `scrollTo({ key, autoExpand: true })`
- 新增实例方法 `getExpandedKeys(key)`
- 展开祖先后等待 motion 完成，再执行实际滚动
- 支持受控和非受控 Tree
- 保留现有 `scrollTo` 参数和 `ScrollOffset` 函数类型兼容性
- 增加中英文 API 文档和受控模式 demo

## API 与行为语义

### `scrollTo({ key, autoExpand })`

`autoExpand` 默认为 `false`，因此现有行为保持不变。

当 `autoExpand: true` 时：

- 只展开目标节点缺失的祖先节点，不展开目标节点本身
- 按根节点到直接父节点的顺序展开
- 保留已有 `expandedKeys` 的顺序和状态
- disabled 祖先节点仍会被展开
- 等待展开动画结束、目标进入渲染列表后再滚动
- 目标必须已经存在于 `treeData`
- 不会触发 `loadData`
- 找不到目标时不执行任何操作
- 如果目标在等待滚动期间被删除，则取消 pending scroll
- 连续调用会累积展开路径，但只滚动到最后一次调用的目标
- Tree 卸载时取消 pending scroll

### `getExpandedKeys(key)`

返回一个新数组：

- 保留当前 `expandedKeys` 的原有顺序
- 按根节点到直接父节点的顺序追加缺失祖先
- 不主动加入目标节点本身
- 不修改 Tree 状态
- 不触发 `onExpand`

### 受控模式

Tree 不会直接修改受控的 `expandedKeys`。

当祖先尚未展开时，`scrollTo({ key, autoExpand: true })` 会停止滚动并在开发环境输出 warning。调用方应：

1. 调用 `getExpandedKeys(key)`
2. 更新受控 `expandedKeys`
3. 等新 props 完成渲染
4. 再次调用 `scrollTo({ key, autoExpand: true })`

第二次调用会等待可能存在的展开动画结束后滚动。

## ⚠️ 需确认的 `onExpand` 语义

当前实现按“每个实际展开动作都应触发对应回调”的语义处理。

假设目标路径为 `root -> folder -> target`，且两个祖先均未展开，将同步触发两次回调：

```ts
onExpand(['root'], {
  node: rootNode,
  expanded: true,
  nativeEvent: undefined,
});

onExpand(['root', 'folder'], {
  node: folderNode,
  expanded: true,
  nativeEvent: undefined,
});
```

即：

- 每个新展开祖先触发一次 `onExpand`
- 顺序为根节点到目标直接父节点
- 每次返回累积的 expanded keys
- `info.expanded` 为 `true`
- 程序化展开没有浏览器事件，因此 `info.nativeEvent` 为 `undefined`
- `nativeEvent` 类型相应调整为可选

请重点确认：是否接受“每个祖先分别触发一次 `onExpand`”的语义，还是希望改成一次聚合回调。

## 测试

覆盖以下场景：

- 祖先路径顺序与缺失目标
- `getExpandedKeys` 顺序、拷贝和受控行为
- 目标节点本身不被展开
- 部分祖先已展开
- disabled 祖先
- 不触发异步加载
- `autoExpand` 默认关闭
- 受控 warning 和更新流程
- motion 完成后滚动
- 函数型 `ScrollOffset`
- 快速连续调用只滚动到最后目标
- 卸载取消 pending scroll
- 动画期间删除并重新加入目标不会触发旧滚动


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `Tree.getExpandedKeys`，支持获取目标节点所需的祖先展开路径。
  - `scrollTo` 支持按节点定位，并可自动展开祖先节点后滚动。
  - 新增滚动配置类型，支持对齐方式、偏移量及自动展开选项。
- **改进**
  - 动画或异步展开完成后再执行滚动，目标失效或组件卸载时自动取消。
  - `onExpand` 的 `nativeEvent` 参数调整为可选。
- **文档**
  - 补充中英文 API 说明及自动展开滚动示例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->