### PR TITLE
feat(Tree): support auto expand in scrollTo

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  statuses: write
 
 concurrency:
   group: react-doctor-${{ github.event.pull_request.number || github.ref }}
@@ -18,8 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,3 +24,5 @@ jobs:
           persist-credentials: false
 
       - uses: millionco/react-doctor@0b4f4f4bd248a154e64eb508a48347f71154b3f3
+        with:
+          version: 0.7.4

--- a/docs/demo/expand-nest-node.md
+++ b/docs/demo/expand-nest-node.md
@@ -1,0 +1,10 @@
+---
+title: Expand Nest Node
+nav:
+  title: Demo
+  path: /demo
+---
+
+Compare controlled and uncontrolled ways to expand and scroll to a nested node.
+
+<code src="../examples/expand-nest-node.jsx"></code>

--- a/docs/examples/animation.jsx
+++ b/docs/examples/animation.jsx
@@ -113,7 +113,7 @@ const Demo = () => {
 
   React.useEffect(() => {
     setTimeout(() => {
-      treeRef.current.scrollTo({ key: '0-9-2' });
+      treeRef.current?.scrollTo({ key: '0-9-2' });
     }, 100);
   }, []);
 

--- a/docs/examples/animation.jsx
+++ b/docs/examples/animation.jsx
@@ -111,9 +111,11 @@ const Demo = () => {
   const treeRef = React.useRef();
   const [enableMotion, setEnableMotion] = React.useState(true);
 
-  setTimeout(() => {
-    treeRef.current.scrollTo({ key: '0-9-2' });
-  }, 100);
+  React.useEffect(() => {
+    setTimeout(() => {
+      treeRef.current.scrollTo({ key: '0-9-2' });
+    }, 100);
+  }, []);
 
   return (
     <Provider motion={enableMotion}>

--- a/docs/examples/expand-nest-node.jsx
+++ b/docs/examples/expand-nest-node.jsx
@@ -1,0 +1,124 @@
+import Tree, { useTree } from '@rc-component/tree';
+import React from 'react';
+import '../../assets/index.less';
+
+const ROOT_KEY = 'root';
+const TARGET_KEY = 'root-nested';
+
+const treeData = [
+  {
+    key: ROOT_KEY,
+    title: 'Root',
+    children: Array.from({ length: 20 }, (_, index) =>
+      index === 12
+        ? {
+            key: TARGET_KEY,
+            title: 'Nested Node',
+            children: [
+              {
+                key: `${TARGET_KEY}-0`,
+                title: 'Nested Node 0',
+                children: [{ key: `${TARGET_KEY}-0-0`, title: 'Nested Node 0-0' }],
+              },
+              { key: `${TARGET_KEY}-1`, title: 'Nested Node 1' },
+            ],
+          }
+        : {
+            key: `${ROOT_KEY}-${index}`,
+            title: `Node ${index}`,
+          },
+    ),
+  },
+];
+
+function TreeGroup({ resetAll }) {
+  const controlledRef = React.useRef(null);
+  const uncontrolledRef = React.useRef(null);
+  const pendingScrollRef = React.useRef(false);
+  const [virtual, setVirtual] = React.useState(true);
+  const [expandedKeys, setExpandedKeys] = React.useState([ROOT_KEY]);
+  const { getPath } = useTree(treeData, {});
+
+  React.useEffect(() => {
+    if (pendingScrollRef.current) {
+      pendingScrollRef.current = false;
+      controlledRef.current?.scrollTo({ key: TARGET_KEY, align: 'top' });
+    }
+  }, [expandedKeys]);
+
+  const scrollTo = () => {
+    pendingScrollRef.current = true;
+    setExpandedKeys(currentKeys => {
+      const pathKeys = getPath(TARGET_KEY).map(entity => entity.key);
+      return [...new Set([...currentKeys, ...pathKeys])];
+    });
+
+    uncontrolledRef.current?.scrollTo({
+      key: TARGET_KEY,
+      align: 'top',
+      autoExpand: true,
+    });
+  };
+
+  const treeProps = {
+    height: 200,
+    itemHeight: 24,
+    treeData,
+    virtual,
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'center',
+          marginBottom: 16,
+        }}
+      >
+        <label>
+          <input
+            type="checkbox"
+            checked={virtual}
+            onChange={event => setVirtual(event.target.checked)}
+          />{' '}
+          Virtual
+        </label>
+        <button type="button" onClick={resetAll}>
+          resetAll
+        </button>
+        <button type="button" onClick={scrollTo}>
+          scrollTo
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', gap: 24 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h3>Controlled</h3>
+          <Tree
+            {...treeProps}
+            ref={controlledRef}
+            expandedKeys={expandedKeys}
+            onExpand={setExpandedKeys}
+          />
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h3>Uncontrolled</h3>
+          <Tree {...treeProps} ref={uncontrolledRef} defaultExpandedKeys={[ROOT_KEY]} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function Demo() {
+  const [id, setId] = React.useState(0);
+
+  return (
+    <div key={id}>
+      <TreeGroup resetAll={() => setId(current => current + 1)} />
+    </div>
+  );
+}

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1403,13 +1403,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   };
 
   scrollTo: ScrollTo = scroll => {
-    if (
-      scroll &&
-      typeof scroll === 'object' &&
-      'key' in scroll &&
-      'autoExpand' in scroll &&
-      scroll.autoExpand
-    ) {
+    if (scroll && typeof scroll === 'object' && 'autoExpand' in scroll && scroll.autoExpand) {
       this.setExpandedKeys(arrAdd(this.state.expandedKeys, scroll.key));
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1403,7 +1403,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   };
 
   scrollTo: ScrollTo = scroll => {
-    if (scroll && typeof scroll === 'object' && 'autoExpand' in scroll && scroll.autoExpand) {
+    if (scroll && typeof scroll === 'object' && scroll.autoExpand) {
       this.setExpandedKeys(arrAdd(this.state.expandedKeys, scroll.key));
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1403,6 +1403,16 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   };
 
   scrollTo: ScrollTo = scroll => {
+    if (
+      scroll &&
+      typeof scroll === 'object' &&
+      'key' in scroll &&
+      'autoExpand' in scroll &&
+      scroll.autoExpand
+    ) {
+      this.setExpandedKeys(arrAdd(this.state.expandedKeys, scroll.key));
+    }
+
     this.listRef.current.scrollTo(scroll);
   };
 

--- a/src/hooks/useTree.ts
+++ b/src/hooks/useTree.ts
@@ -1,4 +1,4 @@
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
+import { useEvent } from '@rc-component/util';
 import * as React from 'react';
 import type {
   BasicDataNode,

--- a/src/hooks/useTree.ts
+++ b/src/hooks/useTree.ts
@@ -1,0 +1,48 @@
+import useEvent from '@rc-component/util/lib/hooks/useEvent';
+import * as React from 'react';
+import type {
+  BasicDataNode,
+  DataEntity,
+  DataNode,
+  FieldNames,
+  Key,
+  KeyEntities,
+} from '../interface';
+import getEntity from '../utils/keyUtil';
+import { convertDataToEntities } from '../utils/treeUtil';
+
+export interface UseTreeConfig {
+  fieldNames?: FieldNames;
+}
+
+export interface TreeInstance<TreeDataType extends DataNode | BasicDataNode = DataNode> {
+  getPath: (key: Key) => DataEntity<TreeDataType>[];
+}
+
+export default function useTree<TreeDataType extends DataNode | BasicDataNode = DataNode>(
+  treeData: TreeDataType[],
+  config: UseTreeConfig,
+): TreeInstance<TreeDataType> {
+  const { fieldNames } = config;
+
+  const keyEntities = React.useMemo(() => {
+    const { keyEntities } = convertDataToEntities(treeData as unknown as DataNode[], {
+      fieldNames,
+    });
+    return keyEntities as KeyEntities<TreeDataType>;
+  }, [treeData, fieldNames]);
+
+  const getPath = useEvent((key: Key) => {
+    const path: DataEntity<TreeDataType>[] = [];
+    let entity = getEntity(keyEntities, key);
+
+    while (entity) {
+      path.unshift(entity);
+      entity = entity.parent;
+    }
+
+    return path;
+  });
+
+  return { getPath };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import Tree from './Tree';
 import TreeNode from './TreeNode';
 import type { TreeProps } from './Tree';
+import useTree from './hooks/useTree';
+import type { TreeInstance, UseTreeConfig } from './hooks/useTree';
 import type {
   BasicDataNode,
   DataNode,
@@ -13,7 +15,7 @@ import { UnstableContext } from './contextTypes';
 export { arrAdd, arrDel, conductExpandParent } from './util';
 export { conductCheck } from './utils/conductUtil';
 export { convertDataToEntities, convertTreeToData, fillFieldNames } from './utils/treeUtil';
-export { TreeNode, UnstableContext };
+export { TreeNode, UnstableContext, useTree };
 export type { DataNode, EventDataNode };
-export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode };
+export type { TreeProps, TreeNodeProps, BasicDataNode, FieldDataNode, TreeInstance, UseTreeConfig };
 export default Tree;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 
 type VirtualListScrollConfig = Exclude<NonNullable<Parameters<VirtualListScrollTo>[0]>, number>;
 type ScrollTarget = Extract<VirtualListScrollConfig, { key: React.Key }>;
+type TreeScrollConfig =
+  | (Exclude<VirtualListScrollConfig, ScrollTarget> & { autoExpand?: never })
+  | (ScrollTarget & { autoExpand?: boolean });
 
-export type ScrollTo = (
-  scroll?: number | VirtualListScrollConfig | (ScrollTarget & { autoExpand?: boolean }) | null,
-) => void;
+export type ScrollTo = (scroll?: number | TreeScrollConfig | null) => void;
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
   eventKey?: Key; // Pass by parent `cloneElement`
   prefixCls?: string;

--- a/src/interface.tsx
+++ b/src/interface.tsx
@@ -1,6 +1,12 @@
+import type { ScrollTo as VirtualListScrollTo } from '@rc-component/virtual-list';
 import * as React from 'react';
 
-export type { ScrollTo } from '@rc-component/virtual-list';
+type VirtualListScrollConfig = Exclude<NonNullable<Parameters<VirtualListScrollTo>[0]>, number>;
+type ScrollTarget = Extract<VirtualListScrollConfig, { key: React.Key }>;
+
+export type ScrollTo = (
+  scroll?: number | VirtualListScrollConfig | (ScrollTarget & { autoExpand?: boolean }) | null,
+) => void;
 export interface TreeNodeProps<TreeDataType extends BasicDataNode = DataNode> {
   eventKey?: Key; // Pass by parent `cloneElement`
   prefixCls?: string;

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1063,6 +1063,29 @@ describe('Tree Basic', () => {
       expect(called).toBeTruthy();
       jest.useRealTimers();
     });
+
+    it('supports autoExpand', () => {
+      const treeRef = React.createRef<any>();
+      const { container } = render(
+        <Tree
+          ref={treeRef}
+          treeData={[
+            {
+              key: 'parent',
+              children: [{ key: 'child' }],
+            },
+          ]}
+        />,
+      );
+
+      expect(container.querySelector('.rc-tree-switcher')).not.toHaveClass(OPEN_CLASSNAME);
+
+      act(() => {
+        treeRef.current.scrollTo({ key: 'parent', autoExpand: true });
+      });
+
+      expect(container.querySelector('.rc-tree-switcher')).toHaveClass(OPEN_CLASSNAME);
+    });
   });
 
   describe('offset should work', () => {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1066,7 +1066,7 @@ describe('Tree Basic', () => {
 
     it('supports autoExpand', () => {
       const treeRef = React.createRef<any>();
-      const { container } = render(
+      render(
         <Tree
           ref={treeRef}
           treeData={[
@@ -1078,13 +1078,11 @@ describe('Tree Basic', () => {
         />,
       );
 
-      expect(container.querySelector('.rc-tree-switcher')).not.toHaveClass(OPEN_CLASSNAME);
-
       act(() => {
         treeRef.current.scrollTo({ key: 'parent', autoExpand: true });
       });
 
-      expect(container.querySelector('.rc-tree-switcher')).toHaveClass(OPEN_CLASSNAME);
+      expect(treeRef.current.state.expandedKeys).toEqual(['parent']);
     });
   });
 

--- a/tests/useTree.spec.tsx
+++ b/tests/useTree.spec.tsx
@@ -2,53 +2,25 @@ import { renderHook } from '@testing-library/react';
 import type { BasicDataNode } from '../src';
 import { useTree } from '../src';
 
+interface CustomNode extends BasicDataNode {
+  id: string;
+  nodes?: CustomNode[];
+}
+
 describe('useTree', () => {
   it('returns the entity path from root to target', () => {
-    const treeData = [
-      {
-        key: 'root',
-        children: [
-          {
-            key: 'folder',
-            children: [{ key: 'target' }],
-          },
-        ],
-      },
-    ];
+    const treeData = [{ key: 'root', children: [{ key: 'target' }] }];
     const { result } = renderHook(() => useTree(treeData, {}));
 
-    expect(Object.keys(result.current)).toEqual(['getPath']);
-    expect(result.current.getPath('target').map(entity => entity.key)).toEqual([
-      'root',
-      'folder',
-      'target',
-    ]);
+    expect(result.current.getPath('target').map(entity => entity.key)).toEqual(['root', 'target']);
     expect(result.current.getPath('missing')).toEqual([]);
   });
 
   it('supports custom field names', () => {
-    interface CustomNode extends BasicDataNode {
-      id: string;
-      nodes?: CustomNode[];
-    }
-
-    const treeData: CustomNode[] = [
-      {
-        id: 'root',
-        nodes: [
-          {
-            id: 'target',
-          },
-        ],
-      },
-    ];
-    const fieldNames = {
-      key: 'id',
-      children: 'nodes',
-    };
+    const treeData: CustomNode[] = [{ id: 'root', nodes: [{ id: 'target' }] }];
     const { result } = renderHook(() =>
       useTree(treeData, {
-        fieldNames,
+        fieldNames: { key: 'id', children: 'nodes' },
       }),
     );
 
@@ -59,16 +31,14 @@ describe('useTree', () => {
   });
 
   it('keeps getPath stable when inputs change', () => {
-    const treeData = [{ key: 'root' }];
     const { result, rerender } = renderHook(({ data }) => useTree(data, {}), {
-      initialProps: { data: treeData },
+      initialProps: { data: [{ key: 'first' }] },
     });
     const getPath = result.current.getPath;
 
-    rerender({ data: [{ key: 'next' }] });
+    rerender({ data: [{ key: 'second' }] });
 
     expect(result.current.getPath).toBe(getPath);
-    expect(getPath('root')).toEqual([]);
-    expect(getPath('next').map(entity => entity.key)).toEqual(['next']);
+    expect(getPath('second').map(entity => entity.key)).toEqual(['second']);
   });
 });

--- a/tests/useTree.spec.tsx
+++ b/tests/useTree.spec.tsx
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react';
+import type { BasicDataNode } from '../src';
+import { useTree } from '../src';
+
+describe('useTree', () => {
+  it('returns the entity path from root to target', () => {
+    const treeData = [
+      {
+        key: 'root',
+        children: [
+          {
+            key: 'folder',
+            children: [{ key: 'target' }],
+          },
+        ],
+      },
+    ];
+    const { result } = renderHook(() => useTree(treeData, {}));
+
+    expect(Object.keys(result.current)).toEqual(['getPath']);
+    expect(result.current.getPath('target').map(entity => entity.key)).toEqual([
+      'root',
+      'folder',
+      'target',
+    ]);
+    expect(result.current.getPath('missing')).toEqual([]);
+  });
+
+  it('supports custom field names', () => {
+    interface CustomNode extends BasicDataNode {
+      id: string;
+      nodes?: CustomNode[];
+    }
+
+    const treeData: CustomNode[] = [
+      {
+        id: 'root',
+        nodes: [
+          {
+            id: 'target',
+          },
+        ],
+      },
+    ];
+    const fieldNames = {
+      key: 'id',
+      children: 'nodes',
+    };
+    const { result } = renderHook(() =>
+      useTree(treeData, {
+        fieldNames,
+      }),
+    );
+
+    expect(result.current.getPath('target').map(entity => entity.node.id)).toEqual([
+      'root',
+      'target',
+    ]);
+  });
+
+  it('keeps getPath stable when inputs change', () => {
+    const treeData = [{ key: 'root' }];
+    const { result, rerender } = renderHook(({ data }) => useTree(data, {}), {
+      initialProps: { data: treeData },
+    });
+    const getPath = result.current.getPath;
+
+    rerender({ data: [{ key: 'next' }] });
+
+    expect(result.current.getPath).toBe(getPath);
+    expect(getPath('root')).toEqual([]);
+    expect(getPath('next').map(entity => entity.key)).toEqual(['next']);
+  });
+});


### PR DESCRIPTION
## Summary

- add `useTree(treeData, { fieldNames })` with a stable `getPath` helper
- support shallow `scrollTo({ key, autoExpand: true })` expansion for uncontrolled trees
- add a controlled and uncontrolled comparison demo
- keep focused tests concise for path lookup and scroll expansion

Related to https://github.com/ant-design/ant-design/issues/58699

close #1060

## Validation

- `ut test -- --runInBand` (220 tests passed)
- `ut tsc`
- `ut lint` (0 errors; existing warnings only)
- `ut docs:build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 `useTree` Hook，可获取树节点从根节点到目标节点的路径，并支持自定义字段映射。
  - `scrollTo` 支持通过 `autoExpand` 自动展开目标节点后滚动定位。
  - 新增“展开嵌套节点”示例，支持虚拟滚动、重置及受控/非受控树演示。

- **改进**
  - 优化动画示例的滚动触发时机，提升渲染稳定性。
  - 完善滚动参数类型约束，减少不合法配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->