### PR TITLE
fix: prevent scroll on tree title descendant focus

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1076,10 +1076,16 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   };
 
   onFocus: React.FocusEventHandler<HTMLDivElement> = (...args) => {
+    const [event] = args;
     const { onFocus, disabled } = this.props;
     const { activeKey, selectedKeys, flattenNodes } = this.state;
 
-    if (!this.focusedByMouse && !disabled && activeKey === null) {
+    if (
+      event.target === event.currentTarget &&
+      !this.focusedByMouse &&
+      !disabled &&
+      activeKey === null
+    ) {
       const visibleSelectedKey = selectedKeys.find(key => {
         return flattenNodes.some(nodeItem => nodeItem.key === key);
       });

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1485,4 +1485,50 @@ describe('Tree Basic', () => {
     expect(scrollToSpy).not.toHaveBeenCalled();
     scrollToSpy.mockRestore();
   });
+
+  it.each([
+    { description: 'a selected node', treeProps: { selectedKeys: ['1'] } },
+    { description: 'selection disabled', treeProps: { selectable: false } },
+  ])(
+    'should not scroll when an interactive title descendant receives focus with $description',
+    ({ treeProps }) => {
+      const data = Array.from({ length: 20 }, (_, index) => ({
+        key: String(index),
+        title: `Node ${index}`,
+      }));
+      const treeRef = React.createRef<any>();
+      const onFocus = jest.fn();
+      const { getByRole } = render(
+        <Tree
+          ref={treeRef}
+          treeData={data}
+          height={100}
+          itemHeight={20}
+          titleRender={node =>
+            node.key === '0' ? (
+              <select aria-label="Node action">
+                <option>Action</option>
+              </select>
+            ) : (
+              node.title
+            )
+          }
+          onFocus={onFocus}
+          {...treeProps}
+        />,
+      );
+      const select = getByRole('combobox');
+      const scrollToSpy = jest.spyOn(treeRef.current, 'scrollTo');
+
+      fireEvent.mouseDown(select);
+      fireEvent.mouseUp(select);
+      expect(treeRef.current.focusedByMouse).toBe(false);
+
+      fireEvent.focus(select);
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(scrollToSpy).not.toHaveBeenCalled();
+      scrollToSpy.mockRestore();
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Focusing an interactive control rendered by `titleRender` bubbles into the Tree and may reset a virtualized tree's scroll position. This change initializes the active item only for direct focus on the tree container while continuing to forward descendant focus events to the public `onFocus` callback.

## Related Links

- Closes https://github.com/react-component/tree/issues/1062
- https://github.com/ant-design/ant-design/issues/58500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 使用 `autoExpand` 滚动到节点时，会自动展开目标节点及其父级路径。

* **问题修复**
  * 修复树组件在特定焦点场景下错误激活节点的问题。
  * 修复标题包含交互式后代元素时，获得焦点可能触发不必要滚动的问题。
  * 优化鼠标聚焦、禁用状态及已有激活节点下的焦点处理行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->