### PR TITLE
test: fix scrollTo test with virtual-list 1.5

### DIFF
--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1052,13 +1052,12 @@ describe('Tree Basic', () => {
     it('work', () => {
       jest.useFakeTimers();
       const treeRef = React.createRef<any>();
-      render(<Tree ref={treeRef} />);
+      render(<Tree ref={treeRef} treeData={[{ key: 'light', title: 'light' }]} />);
 
       act(() => {
         treeRef.current.scrollTo({ key: 'light', align: 'top' });
+        jest.runAllTimers();
       });
-
-      jest.runAllTimers();
 
       expect(called).toBeTruthy();
       jest.useRealTimers();


### PR DESCRIPTION
## Summary

- render a tree node matching the key used by the `scrollTo` test
- flush fake timers inside `act`

## Context

`@rc-component/virtual-list` 1.5.x no longer updates `scrollTop` for a key that is absent from the current data. The existing test rendered an empty tree and attempted to scroll to `light`, so it relied on the previous incidental behavior and started failing after the dependency update.

## Verification

- `ut test -- tests/Tree.spec.tsx -t 'scrollTo should work' --runInBand`
- `prettier --check tests/Tree.spec.tsx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新树组件的滚动定位测试，使用实际存在的节点数据进行验证。
  * 改进定时器处理，确保测试准确覆盖节点滚动行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->