### PR TITLE
fix: guard scrollTo against a detached list ref

### DIFF
--- a/src/NodeList.tsx
+++ b/src/NodeList.tsx
@@ -161,7 +161,7 @@ const NodeList = React.forwardRef<NodeListRef, NodeListProps<any>>((props, ref) 
   const indentMeasurerRef = React.useRef<HTMLDivElement>(null);
   React.useImperativeHandle(ref, () => ({
     scrollTo: scroll => {
-      listRef.current.scrollTo(scroll);
+      listRef.current?.scrollTo(scroll);
     },
     getIndentWidth: () => indentMeasurerRef.current.offsetWidth,
   }));

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -1407,7 +1407,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       this.setExpandedKeys(arrAdd(this.state.expandedKeys, scroll.key));
     }
 
-    this.listRef.current.scrollTo(scroll);
+    this.listRef.current?.scrollTo(scroll);
   };
 
   render() {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1083,6 +1083,26 @@ describe('Tree Basic', () => {
 
       expect(treeRef.current.state.expandedKeys).toEqual(['parent']);
     });
+
+    it('does not crash when focus activation fires before the list ref attaches', async () => {
+      // An autoFocus title focuses during the commit mutation phase, before
+      // NodeList's imperative handle re-attaches in the layout phase. The
+      // bubbled focus triggers activation -> scrollTo on a null listRef.
+      // React rethrows event handler errors globally, so capture window errors.
+      const errors: unknown[] = [];
+      const onWindowError = (e: ErrorEvent) => {
+        errors.push(e.error ?? e.message);
+        e.preventDefault();
+      };
+      window.addEventListener('error', onWindowError);
+      try {
+        render(<Tree treeData={[{ key: 'a', title: <input autoFocus /> }]} />);
+        await delay();
+        expect(errors).toEqual([]);
+      } finally {
+        window.removeEventListener('error', onWindowError);
+      }
+    });
   });
 
   describe('offset should work', () => {


### PR DESCRIPTION
`NodeList`'s `useImperativeHandle` has no dependency array, so every re-render detaches the handle during the commit's mutation phase and re-attaches it in the layout phase. Anything that runs between those two — for example an `autoFocus` input mounting inside a node title, whose bubbled focus triggers the tree's focus activation and `scrollTo` — dereferences a null `listRef` and unmounts the whole React root.

This adds optional chaining at the two `listRef.current.scrollTo` call sites, plus a regression test that reproduces the crash on first mount (fails with `TypeError: Cannot read properties of null (reading 'scrollTo')` without the fix).

Downstream, this crash reaches every antd `Tree` / `TreeSelect` / `Cascader` consumer.

All checks pass locally: `lint` (0 errors), `tsc`, `test --runInBand` (223/223), `build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复列表尚未完成初始化时执行滚动操作导致页面报错的问题。
  * 改善带有自动聚焦控件的树节点加载体验，避免触发未捕获的全局错误。

* **Tests**
  * 新增回归测试，验证列表引用尚未就绪时自动聚焦不会产生错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1068
