### PR TITLE
fix: treat `undefined` props as uncontrolled

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -430,9 +430,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (newState.expandedKeys === null) {
-      newState.expandedKeys = [];
-    } else if (!newState.expandedKeys) {
+    if (!newState.expandedKeys) {
       delete newState.expandedKeys;
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -404,11 +404,16 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     const keyEntities = newState.keyEntities || prevState.keyEntities;
 
     // ================ expandedKeys =================
-    if (needSync('expandedKeys') || (prevProps && needSync('autoExpandParent'))) {
+    if (
+      needSync('expandedKeys') ||
+      (prevProps && needSync('autoExpandParent') && props.expandedKeys !== undefined)
+    ) {
+      // Controlled -> uncontrolled resets to empty, same as `useControlledState`
+      const expandedKeys = props.expandedKeys ?? [];
       newState.expandedKeys =
         props.autoExpandParent || (!prevProps && props.defaultExpandParent)
-          ? conductExpandParent(props.expandedKeys, keyEntities)
-          : props.expandedKeys;
+          ? conductExpandParent(expandedKeys, keyEntities)
+          : expandedKeys;
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
@@ -430,10 +435,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (!newState.expandedKeys) {
-      delete newState.expandedKeys;
-    }
-
     // ================ flattenNodes =================
     if (treeData || newState.expandedKeys) {
       const flattenNodes = flattenTreeData<DataNode>(
@@ -447,7 +448,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     // ================ selectedKeys =================
     if (props.selectable) {
       if (needSync('selectedKeys')) {
-        newState.selectedKeys = calcSelectedKeys(props.selectedKeys, props);
+        newState.selectedKeys = calcSelectedKeys(props.selectedKeys ?? [], props);
       } else if (!prevProps && props.defaultSelectedKeys) {
         newState.selectedKeys = calcSelectedKeys(props.defaultSelectedKeys, props);
       }
@@ -484,7 +485,13 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
     // ================= loadedKeys ==================
     if (needSync('loadedKeys')) {
-      newState.loadedKeys = props.loadedKeys;
+      newState.loadedKeys = props.loadedKeys ?? [];
+    }
+
+    // ================== activeKey ==================
+    // Controlled value is synced in `onUpdated` (needs scroll). Only handle release here.
+    if (prevProps && needSync('activeKey') && props.activeKey === undefined) {
+      newState.activeKey = null;
     }
 
     return newState;

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -430,7 +430,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (!newState.expandedKeys) {
+    if (newState.expandedKeys === null) {
+      newState.expandedKeys = [];
+    } else if (!newState.expandedKeys) {
       delete newState.expandedKeys;
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -364,7 +364,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
     function needSync(name: string) {
       return (
-        (!prevProps && props.hasOwnProperty(name)) || (prevProps && prevProps[name] !== props[name])
+        (!prevProps && props[name] !== undefined) || (prevProps && prevProps[name] !== props[name])
       );
     }
 
@@ -1139,7 +1139,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   /** Set uncontrolled `expandedKeys`. This will also auto update `flattenNodes`. */
   setExpandedKeys = (expandedKeys: Key[]) => {
     // When `expandedKeys` is controlled, `setUncontrolledState` with `atomic` will be a no-op.
-    if (this.props.hasOwnProperty('expandedKeys')) {
+    if (this.props.expandedKeys !== undefined) {
       return;
     }
     const { treeData, fieldNames } = this.state;
@@ -1393,7 +1393,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       const newState = {};
 
       Object.keys(state).forEach(name => {
-        if (this.props.hasOwnProperty(name)) {
+        if (this.props[name] !== undefined) {
           allPassed = false;
           return;
         }

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -408,7 +408,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       needSync('expandedKeys') ||
       (prevProps && needSync('autoExpandParent') && props.expandedKeys !== undefined)
     ) {
-      // Controlled -> uncontrolled resets to empty, same as `useControlledState`
+      // Controlled -> uncontrolled resets to empty
       const expandedKeys = props.expandedKeys ?? [];
       newState.expandedKeys =
         props.autoExpandParent || (!prevProps && props.defaultExpandParent)

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1149,13 +1149,45 @@ describe('Tree Basic', () => {
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
     ).toHaveLength(2);
 
+    // Controlled -> uncontrolled resets to empty
     rerender(renderTree({ expandedKeys: undefined }));
-
-    // Click should not crash
-    fireEvent.click(container.querySelector('.rc-tree-switcher'));
     expect(
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
     ).toHaveLength(1);
+
+    // Now uncontrolled, click should expand
+    fireEvent.click(container.querySelector('.rc-tree-switcher'));
+    expect(
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
+    ).toHaveLength(2);
+  });
+
+  it('controlled -> uncontrolled resets every controlled key prop', () => {
+    const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
+    const renderTree = (props?: any) => (
+      <Tree treeData={treeData} checkable expandedKeys={['p']} {...props} />
+    );
+    const { container, rerender } = render(
+      renderTree({ selectedKeys: ['p'], checkedKeys: ['c'], loadedKeys: ['p'], activeKey: 'p' }),
+    );
+    expect(container.querySelectorAll('.rc-tree-node-selected')).toHaveLength(1);
+    expect(container.querySelectorAll('.rc-tree-checkbox-checked')).toHaveLength(2);
+    expect(container.querySelectorAll('.rc-tree-treenode-active')).toHaveLength(1);
+
+    rerender(
+      renderTree({
+        selectedKeys: undefined,
+        checkedKeys: undefined,
+        loadedKeys: undefined,
+        activeKey: undefined,
+      }),
+    );
+    expect(container.querySelectorAll('.rc-tree-node-selected')).toHaveLength(0);
+    expect(container.querySelectorAll('.rc-tree-checkbox-checked')).toHaveLength(0);
+    expect(container.querySelectorAll('.rc-tree-treenode-active')).toHaveLength(0);
+
+    // Focus after release should not crash on `selectedKeys.find`
+    fireEvent.focus(container.querySelector('[role="tree"]'));
   });
 
   it('`undefined` means uncontrolled', () => {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1168,11 +1168,17 @@ describe('Tree Basic', () => {
     fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
     expect(nodeCount(uncontrolled)).toBe(1);
 
-    const { container: controlled } = render(
+    const { container: controlled, rerender } = render(
       <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
     );
     expect(nodeCount(controlled)).toBe(1);
     fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(controlled)).toBe(1);
+
+    // Switching an existing value to `null` collapses
+    rerender(<Tree treeData={treeData} expandedKeys={['p']} />);
+    expect(nodeCount(controlled)).toBe(2);
+    rerender(<Tree treeData={treeData} expandedKeys={null} />);
     expect(nodeCount(controlled)).toBe(1);
   });
 

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1156,7 +1156,7 @@ describe('Tree Basic', () => {
     ).toHaveLength(1);
   });
 
-  it('`undefined` is uncontrolled but `null` is a controlled empty value', () => {
+  it('`undefined` means uncontrolled', () => {
     const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
     const nodeCount = (container: HTMLElement) =>
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode').length;
@@ -1168,17 +1168,12 @@ describe('Tree Basic', () => {
     fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
     expect(nodeCount(uncontrolled)).toBe(1);
 
-    const { container: controlled, rerender } = render(
-      <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
+    // An empty array is still controlled, so it wins over `defaultExpandAll`
+    const { container: controlled } = render(
+      <Tree treeData={treeData} expandedKeys={[]} defaultExpandAll />,
     );
     expect(nodeCount(controlled)).toBe(1);
     fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
-    expect(nodeCount(controlled)).toBe(1);
-
-    // Switching an existing value to `null` collapses
-    rerender(<Tree treeData={treeData} expandedKeys={['p']} />);
-    expect(nodeCount(controlled)).toBe(2);
-    rerender(<Tree treeData={treeData} expandedKeys={null} />);
     expect(nodeCount(controlled)).toBe(1);
   });
 

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1150,9 +1150,30 @@ describe('Tree Basic', () => {
     ).toHaveLength(2);
 
     rerender(renderTree({ expandedKeys: undefined }));
-
-    // Click should not crash
     fireEvent.click(container.querySelector('.rc-tree-switcher'));
+    expect(
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
+    ).toHaveLength(1);
+  });
+
+  it('`undefined` is uncontrolled but `null` is a controlled empty value', () => {
+    const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
+    const nodeCount = (container: HTMLElement) =>
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode').length;
+
+    const { container: uncontrolled } = render(
+      <Tree treeData={treeData} expandedKeys={undefined} defaultExpandAll />,
+    );
+    expect(nodeCount(uncontrolled)).toBe(2);
+    fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(uncontrolled)).toBe(1);
+
+    const { container: controlled } = render(
+      <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
+    );
+    expect(nodeCount(controlled)).toBe(1);
+    fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(controlled)).toBe(1);
   });
 
   it('controlled should block expanded', () => {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1150,6 +1150,8 @@ describe('Tree Basic', () => {
     ).toHaveLength(2);
 
     rerender(renderTree({ expandedKeys: undefined }));
+
+    // Click should not crash
     fireEvent.click(container.querySelector('.rc-tree-switcher'));
     expect(
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -262,6 +262,7 @@ describe('Tree Motion', () => {
 
     rerender(
       renderTree({
+        expandedKeys: ['parent'],
         treeData: [
           {
             key: 'parent',


### PR DESCRIPTION
## Why

`Tree` used `props.hasOwnProperty(name)` to decide whether a prop is controlled. That treats `expandedKeys={undefined}` as controlled, which is wrong and easy to hit when a wrapper passes props through (`<Tree expandedKeys={maybeUndefined} />`). Every other rc-component follows `useControlledState` / `useMergedState` from `@rc-component/util`, where only `undefined` means "uncontrolled".

## What

1. `undefined` means uncontrolled. `needSync` / `setUncontrolledState` / `setExpandedKeys` now check `!== undefined` instead of `hasOwnProperty`. An empty array is still a controlled value and wins over `defaultExpandAll` etc.

2. Controlled → uncontrolled resets state, same as `useControlledState`. Before this PR each prop behaved differently when it went from a value to `undefined`:

   | prop | before | after |
   |---|---|---|
   | `expandedKeys` | kept last controlled value | `[]` |
   | `selectedKeys` | state became `undefined`, `selectedKeys.find` threw on focus | `[]` |
   | `checkedKeys` | `[]` | unchanged |
   | `loadedKeys` | state became `undefined` | `[]` |
   | `activeKey` | kept last controlled value | `null` |

   `activeKey` is only handled for the release case in `getDerivedStateFromProps`; the controlled value is still synced in `onUpdated` because it needs to scroll.

3. Toggling `autoExpandParent` while uncontrolled no longer touches `expandedKeys` (previously flipping it to `true` cleared them).

`null` is not given a meaning. It is outside the declared type; it still doesn't crash, which is all it gets.

## Tests

- `not crash if expandedKeys change to undefined` now asserts the reset instead of the old keep-last-value behaviour.
- New case covering the release of all five props.
- `TreeMotion.spec.tsx` "motion should not revert flatten list" dropped `expandedKeys` on its last rerender by accident and relied on the old behaviour; it now stays controlled so it keeps testing only motion.