### PR TITLE
fix: preserve nested first-child drop target

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -122,7 +122,9 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
     targetNodeProps.eventKey,
   );
 
-  if (clientY < top + height / 2) {
+  const dropBeforeTarget = clientY < top + height / 2 && isFirstChild(abstractDropNodeEntity);
+
+  if (clientY < top + height / 2 && !dropBeforeTarget) {
     // first half, set abstract drop node to previous node
     const nodeIndex = flattenedNodes.findIndex(
       flattenedNode => flattenedNode.key === abstractDropNodeEntity.key,
@@ -156,9 +158,7 @@ export function calcDropPosition<TreeDataType extends BasicDataNode = DataNode>(
   const abstractDropDataNode = abstractDropNodeEntity.node;
   let dropAllowed = true;
   if (
-    isFirstChild(abstractDropNodeEntity) &&
-    abstractDropNodeEntity.level === 0 &&
-    clientY < top + height / 2 &&
+    dropBeforeTarget &&
     allowDrop({
       dragNode: abstractDragDataNode,
       dropNode: abstractDropDataNode,

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -238,6 +238,50 @@ describe('Tree Draggable', () => {
       const base = dir === 'ltr' ? 1 : -1;
 
       describe(dir, () => {
+        it('drops before the first child of an expanded node', () => {
+          const onDrop = jest.fn();
+          const allowDrop = jest.fn(() => true);
+          const { container } = render(
+            <Tree draggable defaultExpandAll onDrop={onDrop} allowDrop={allowDrop} direction={dir}>
+              <TreeNode key="0-0">
+                <TreeNode key="0-0-0" className="dropTarget" />
+                <TreeNode key="0-0-1" className="dragTarget" />
+              </TreeNode>
+            </Tree>,
+          );
+
+          fireDragEvent(
+            container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'),
+            'dragStart',
+            { clientX: base * 500, clientY: 20 },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragEnter',
+            { clientX: base * 500, clientY: 0 },
+          );
+          fireDragEvent(
+            container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'),
+            'dragOver',
+            { clientX: base * 500, clientY: 0 },
+          );
+          fireEvent.drop(container.querySelector('.dropTarget > .rc-tree-node-content-wrapper'));
+
+          expect(onDrop).toHaveBeenCalledWith(
+            expect.objectContaining({
+              node: expect.objectContaining({ key: '0-0-0' }),
+              dropToGap: true,
+              dropPosition: -1,
+            }),
+          );
+          expect(allowDrop).toHaveBeenCalledWith(
+            expect.objectContaining({
+              dropNode: expect.objectContaining({ key: '0-0-0' }),
+              dropPosition: -1,
+            }),
+          );
+        });
+
         it('not allow cross level dnd on expanded nodes', () => {
           const onDrop = jest.fn();
           const { container } = render(


### PR DESCRIPTION
## Summary

- preserve the hovered first child as the drop target when inserting before it inside an expanded parent
- return the nested child through `onDrop.node` with `dropToGap=true` and the correct relative position
- cover both LTR and RTL drag geometry, including the `allowDrop` contract

## Problem

When the pointer enters the upper half of the first child of an expanded node, `calcDropPosition` currently replaces that child with the previous flattened node, which is its parent. Dropping a sibling before that first child therefore reports the parent with an inside drop instead of the child with a gap drop.

The root-level special case does not cover nested first children. Simply removing its level guard is insufficient because the target has already been replaced by the parent.

## Solution

Detect the first-child upper-half case before the flattened-node fallback. This keeps the real hovered child as the abstract drop target, then reuses the existing before-target and `allowDrop({ dropPosition: -1 })` path.

Close ant-design/ant-design#59099.

## Verification

- exact base regression: failed in both LTR and RTL with actual node `0-0`, `dropToGap=false`, `dropPosition=0`
- focused `TreeDraggable.spec.tsx`: 38/38 passed
- full test suite: 226/226 passed, 42/42 snapshots
- TypeScript: passed
- ESLint: 0 errors (11 existing warnings)
- Prettier: passed
- ESM/CJS compile: passed
- `git diff --check`: passed

I checked current open rc-tree PRs and found no duplicate implementation. The existing target-file overlaps are unrelated broad or stale changes.

AI assistance disclosure: Codex assisted with source tracing, the exact-base reproduction, implementation, validation, duplicate screening, and this description. The behavior and final diff were verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化树形拖拽放置判断，修复拖动到已展开节点首个子节点上方时的放置位置问题。
  - 改进从左到右和从右到左布局下的拖放行为，确保目标节点与放置位置信息正确传递。

- **测试**
  - 新增相关拖拽场景测试，覆盖间隙放置及放置位置校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->