### PR TITLE
fix: preserve drag text set by consumers

### DIFF
--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -129,7 +129,6 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
   const onDragStart = (e: React.DragEvent<HTMLDivElement>) => {
     e.stopPropagation();
     setDragNodeHighlight(true);
-    context.onNodeDragStart(e, props);
     try {
       // ie throw error
       // firefox-need-it
@@ -137,6 +136,7 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
     } catch {
       // empty
     }
+    context.onNodeDragStart(e, props);
   };
 
   const onDragEnter = (e: React.DragEvent<HTMLDivElement>) => {

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -46,6 +46,31 @@ describe('Tree Draggable', () => {
     );
   });
 
+  it('preserves text data set by onDragStart', () => {
+    const data = new Map<string, string>();
+    const dataTransfer = {
+      setData: jest.fn((type: string, value: string) => data.set(type, value)),
+      getData: jest.fn((type: string) => data.get(type) || ''),
+    };
+    const onDragStart = jest.fn(({ event }) => {
+      event.dataTransfer.setData('text/plain', 'custom drag data');
+    });
+    const { container } = render(createTree({ onDragStart }));
+    const treeNode = container.querySelector(
+      '.dragTarget > .rc-tree-node-content-wrapper',
+    ) as HTMLElement;
+    const event = createEvent.dragStart(treeNode);
+    Object.defineProperty(event, 'dataTransfer', { value: dataTransfer });
+
+    fireEvent(treeNode, event);
+
+    expect(dataTransfer.setData.mock.calls).toEqual([
+      ['text/plain', ''],
+      ['text/plain', 'custom drag data'],
+    ]);
+    expect(dataTransfer.getData('text/plain')).toBe('custom drag data');
+  });
+
   it('fires dragEnter event', async () => {
     const onDragEnter = jest.fn();
     const { container } = render(createTree({ onDragEnter }));


### PR DESCRIPTION
## Summary

- initialize the Firefox `text/plain` drag fallback before invoking the consumer callback
- allow `onDragStart` consumers to set or override the drag text payload
- add a regression test for the call order and final `DataTransfer` value

Fixes #931.

## Why

The Firefox fallback is still required, but applying it after the consumer callback overwrote any `text/plain` value set by the consumer. Initializing it first preserves the fallback while allowing the public callback to provide the actual payload.

## Verification

- exact-base regression failed before the fix: the custom value was followed by an empty fallback
- `TreeDraggable.spec.tsx`: 37/37 tests passed
- full suite: 14 suites, 225 tests, and 42 snapshots passed
- TypeScript check passed
- lint passed with 0 errors (11 existing warnings)
- compile passed for ESM, CJS, declarations, and CSS
- Prettier check passed for changed files
- `git diff --check` passed

AI assistance disclosure: Codex was used to trace the drag-start flow, implement the focused fix, add the regression test, and run verification. The behavior and test results above were verified in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复节点拖拽时自定义拖拽数据可能被默认逻辑覆盖的问题。
  * 现在可正确保留并读取自定义的 `text/plain` 拖拽内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->