### PR TITLE
fix: cancel drag expansion on unmount

### DIFF
--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -343,10 +343,18 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   }
 
   componentWillUnmount() {
+    this.clearDelayedDragEnterLogic();
     window.removeEventListener('dragend', this.onWindowDragEnd);
     window.removeEventListener('mouseup', this.onGlobalMouseUp);
     this.destroyed = true;
   }
+
+  clearDelayedDragEnterLogic = () => {
+    Object.values(this.delayedDragEnterLogic || {}).forEach(timeoutId => {
+      clearTimeout(timeoutId);
+    });
+    this.delayedDragEnterLogic = {};
+  };
 
   static getDerivedStateFromProps(props: TreeProps, prevState: TreeState) {
     const { prevProps } = prevState;
@@ -565,12 +573,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     }
 
     // Side effect for delay drag
-    if (!this.delayedDragEnterLogic) {
-      this.delayedDragEnterLogic = {};
-    }
-    Object.keys(this.delayedDragEnterLogic).forEach(key => {
-      clearTimeout(this.delayedDragEnterLogic[key]);
-    });
+    this.clearDelayedDragEnterLogic();
 
     if (this.dragNodeProps.eventKey !== nodeProps.eventKey) {
       // hoist expand logic here

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -265,7 +265,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
   destroyed: boolean = false;
 
-  delayedDragEnterLogic: Record<SafeKey, number>;
+  delayedDragEnterLogic: Record<SafeKey, number> = {};
 
   loadingRetryTimes: Record<SafeKey, number> = {};
 
@@ -350,7 +350,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   }
 
   clearDelayedDragEnterLogic = () => {
-    Object.values(this.delayedDragEnterLogic || {}).forEach(timeoutId => {
+    Object.values(this.delayedDragEnterLogic).forEach(timeoutId => {
       clearTimeout(timeoutId);
     });
     this.delayedDragEnterLogic = {};

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -117,6 +117,27 @@ describe('Tree Draggable', () => {
     }
   });
 
+  it('ignores delayed drag expansion after drag end', () => {
+    jest.useFakeTimers();
+    try {
+      const onExpand = jest.fn();
+      const { container } = render(createTree({ onExpand }));
+
+      const dragTarget = container.querySelector('.dragTarget > .rc-tree-node-content-wrapper');
+      fireEvent.dragStart(dragTarget);
+      fireEvent.dragEnter(container.querySelector('.dropTarget'));
+      fireEvent.dragEnd(dragTarget);
+
+      act(() => {
+        jest.advanceTimersByTime(800);
+      });
+
+      expect(onExpand).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('fires dragOver event', () => {
     const onDragOver = jest.fn();
     const { container } = render(createTree({ onDragOver }));

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -99,19 +99,22 @@ describe('Tree Draggable', () => {
 
   it('cancels delayed drag expansion on unmount', () => {
     jest.useFakeTimers();
-    const onExpand = jest.fn();
-    const { container, unmount } = render(createTree({ onExpand }));
+    try {
+      const onExpand = jest.fn();
+      const { container, unmount } = render(createTree({ onExpand }));
 
-    fireEvent.dragStart(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
-    fireEvent.dragEnter(container.querySelector('.dropTarget'));
-    unmount();
+      fireEvent.dragStart(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
+      fireEvent.dragEnter(container.querySelector('.dropTarget'));
+      unmount();
 
-    act(() => {
-      jest.advanceTimersByTime(800);
-    });
+      act(() => {
+        jest.advanceTimersByTime(800);
+      });
 
-    expect(onExpand).not.toHaveBeenCalled();
-    jest.useRealTimers();
+      expect(onExpand).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('fires dragOver event', () => {

--- a/tests/TreeDraggable.spec.tsx
+++ b/tests/TreeDraggable.spec.tsx
@@ -97,6 +97,23 @@ describe('Tree Draggable', () => {
     expect(onDragEnter).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels delayed drag expansion on unmount', () => {
+    jest.useFakeTimers();
+    const onExpand = jest.fn();
+    const { container, unmount } = render(createTree({ onExpand }));
+
+    fireEvent.dragStart(container.querySelector('.dragTarget > .rc-tree-node-content-wrapper'));
+    fireEvent.dragEnter(container.querySelector('.dropTarget'));
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(800);
+    });
+
+    expect(onExpand).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
   it('fires dragOver event', () => {
     const onDragOver = jest.fn();
     const { container } = render(createTree({ onDragOver }));


### PR DESCRIPTION
## Summary

- centralize cleanup for delayed drag-enter expansion timers
- cancel pending timers when the Tree unmounts
- add a regression test that prevents `onExpand` after unmount

## Problem

Drag-enter schedules an 800 ms expansion callback. The next drag-enter clears older callbacks, but `componentWillUnmount` only removed window listeners. If a Tree unmounted during that delay, the stale callback still ran and invoked the consumer `onExpand` after the component had gone away.

The regression test reproduces this by starting a drag, entering a target, unmounting, and advancing the timer. It fails on current master because `onExpand` is called once.

## Validation

- `rc-test --runInBand` (14 suites, 228 tests, 42 snapshots)
- `tsc -p tsconfig.json --noEmit`
- ESLint on `src` (no errors; 11 existing warnings)
- `father build` (ESM, CJS, declarations)
- Less compilation
- Prettier and `git diff --check`

I checked current open issues and PRs. The broad class-to-hooks refactor #1021 retains the same delayed timer without unmount cleanup; no existing PR or issue implements this focused fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复拖拽操作结束或组件卸载后，延迟展开仍可能执行的问题。
  - 防止已结束的拖拽触发展开回调，提升拖拽交互稳定性。

- **测试**
  - 新增测试，验证拖拽结束后延迟展开定时器会被正确清理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->