### PR TITLE
refactor: use renderable guards for node icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@rc-component/motion": "^1.0.0",
-    "@rc-component/util": "^1.11.1",
+    "@rc-component/util": "^1.13.0",
     "@rc-component/virtual-list": "^1.2.0",
     "clsx": "^2.1.1"
   },

--- a/src/TreeNode.tsx
+++ b/src/TreeNode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { clsx } from 'clsx';
-import { getId, pickAttrs } from '@rc-component/util';
+import { getId, isReactRenderable, pickAttrs } from '@rc-component/util';
 import { TreeContext, UnstableContext } from './contextTypes';
 import Indent from './Indent';
 import type { TreeNodeProps } from './interface';
@@ -340,9 +340,9 @@ const TreeNode: React.FC<Readonly<TreeNodeProps>> = props => {
     let $icon: React.ReactNode;
 
     if (context.showIcon) {
-      const currentIcon = props.icon || context.icon;
+      const currentIcon = isReactRenderable(props.icon) ? props.icon : context.icon;
 
-      $icon = currentIcon ? (
+      $icon = isReactRenderable(currentIcon) ? (
         <span
           className={clsx(
             treeClassNames?.itemIcon,


### PR DESCRIPTION
## 说明

- 使用 `isReactRenderable` 统一判断节点图标和全局图标
- 保留节点图标到全局图标的回退顺序
- 支持数字 `0`、`NaN` 等有效 React 内容
- 将 `@rc-component/util` 的最低版本提升到首次提供该 helper 的 `^1.13.0`

## 验证

- `npm run tsc`
- `npm test -- --runInBand`
- `git diff --check`

关联 ant-design/ant-design#59193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进树节点自定义图标的渲染判断，确保不可渲染的图标内容能够正确回退到默认图标。
  * 提升对不同图标内容的兼容性，减少图标显示异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->