### PR TITLE
chore: drop stale eslint-disable comments

### DIFF
--- a/docs/examples/basic.jsx
+++ b/docs/examples/basic.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-alert, no-console, react/no-find-dom-node */
 import React from 'react';
 import '../../assets/index.less';
 import './basic.less';

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -430,9 +430,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (newState.expandedKeys === null) {
-      newState.expandedKeys = [];
-    } else if (!newState.expandedKeys) {
+    if (!newState.expandedKeys) {
       delete newState.expandedKeys;
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -404,11 +404,16 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     const keyEntities = newState.keyEntities || prevState.keyEntities;
 
     // ================ expandedKeys =================
-    if (needSync('expandedKeys') || (prevProps && needSync('autoExpandParent'))) {
+    if (
+      needSync('expandedKeys') ||
+      (prevProps && needSync('autoExpandParent') && props.expandedKeys !== undefined)
+    ) {
+      // Controlled -> uncontrolled resets to empty, same as `useControlledState`
+      const expandedKeys = props.expandedKeys ?? [];
       newState.expandedKeys =
         props.autoExpandParent || (!prevProps && props.defaultExpandParent)
-          ? conductExpandParent(props.expandedKeys, keyEntities)
-          : props.expandedKeys;
+          ? conductExpandParent(expandedKeys, keyEntities)
+          : expandedKeys;
     } else if (!prevProps && props.defaultExpandAll) {
       const cloneKeyEntities = { ...keyEntities };
       delete cloneKeyEntities[MOTION_KEY];
@@ -430,10 +435,6 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (!newState.expandedKeys) {
-      delete newState.expandedKeys;
-    }
-
     // ================ flattenNodes =================
     if (treeData || newState.expandedKeys) {
       const flattenNodes = flattenTreeData<DataNode>(
@@ -447,7 +448,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
     // ================ selectedKeys =================
     if (props.selectable) {
       if (needSync('selectedKeys')) {
-        newState.selectedKeys = calcSelectedKeys(props.selectedKeys, props);
+        newState.selectedKeys = calcSelectedKeys(props.selectedKeys ?? [], props);
       } else if (!prevProps && props.defaultSelectedKeys) {
         newState.selectedKeys = calcSelectedKeys(props.defaultSelectedKeys, props);
       }
@@ -484,7 +485,13 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
     // ================= loadedKeys ==================
     if (needSync('loadedKeys')) {
-      newState.loadedKeys = props.loadedKeys;
+      newState.loadedKeys = props.loadedKeys ?? [];
+    }
+
+    // ================== activeKey ==================
+    // Controlled value is synced in `onUpdated` (needs scroll). Only handle release here.
+    if (prevProps && needSync('activeKey') && props.activeKey === undefined) {
+      newState.activeKey = null;
     }
 
     return newState;

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -430,7 +430,9 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
           : props.defaultExpandedKeys;
     }
 
-    if (!newState.expandedKeys) {
+    if (newState.expandedKeys === null) {
+      newState.expandedKeys = [];
+    } else if (!newState.expandedKeys) {
       delete newState.expandedKeys;
     }
 

--- a/src/Tree.tsx
+++ b/src/Tree.tsx
@@ -364,7 +364,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
 
     function needSync(name: string) {
       return (
-        (!prevProps && props.hasOwnProperty(name)) || (prevProps && prevProps[name] !== props[name])
+        (!prevProps && props[name] !== undefined) || (prevProps && prevProps[name] !== props[name])
       );
     }
 
@@ -1139,7 +1139,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
   /** Set uncontrolled `expandedKeys`. This will also auto update `flattenNodes`. */
   setExpandedKeys = (expandedKeys: Key[]) => {
     // When `expandedKeys` is controlled, `setUncontrolledState` with `atomic` will be a no-op.
-    if (this.props.hasOwnProperty('expandedKeys')) {
+    if (this.props.expandedKeys !== undefined) {
       return;
     }
     const { treeData, fieldNames } = this.state;
@@ -1393,7 +1393,7 @@ class Tree<TreeDataType extends DataNode | BasicDataNode = DataNode> extends Rea
       const newState = {};
 
       Object.keys(state).forEach(name => {
-        if (this.props.hasOwnProperty(name)) {
+        if (this.props[name] !== undefined) {
           allPassed = false;
           return;
         }

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,8 +1,3 @@
-/* eslint-disable no-lonely-if */
-/**
- * Legacy code. Should avoid to use if you are new to import these code.
- */
-
 import { warning } from '@rc-component/util';
 import React from 'react';
 import type {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1149,13 +1149,45 @@ describe('Tree Basic', () => {
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
     ).toHaveLength(2);
 
+    // Controlled -> uncontrolled resets to empty
     rerender(renderTree({ expandedKeys: undefined }));
-
-    // Click should not crash
-    fireEvent.click(container.querySelector('.rc-tree-switcher'));
     expect(
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
     ).toHaveLength(1);
+
+    // Now uncontrolled, click should expand
+    fireEvent.click(container.querySelector('.rc-tree-switcher'));
+    expect(
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
+    ).toHaveLength(2);
+  });
+
+  it('controlled -> uncontrolled resets every controlled key prop', () => {
+    const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
+    const renderTree = (props?: any) => (
+      <Tree treeData={treeData} checkable expandedKeys={['p']} {...props} />
+    );
+    const { container, rerender } = render(
+      renderTree({ selectedKeys: ['p'], checkedKeys: ['c'], loadedKeys: ['p'], activeKey: 'p' }),
+    );
+    expect(container.querySelectorAll('.rc-tree-node-selected')).toHaveLength(1);
+    expect(container.querySelectorAll('.rc-tree-checkbox-checked')).toHaveLength(2);
+    expect(container.querySelectorAll('.rc-tree-treenode-active')).toHaveLength(1);
+
+    rerender(
+      renderTree({
+        selectedKeys: undefined,
+        checkedKeys: undefined,
+        loadedKeys: undefined,
+        activeKey: undefined,
+      }),
+    );
+    expect(container.querySelectorAll('.rc-tree-node-selected')).toHaveLength(0);
+    expect(container.querySelectorAll('.rc-tree-checkbox-checked')).toHaveLength(0);
+    expect(container.querySelectorAll('.rc-tree-treenode-active')).toHaveLength(0);
+
+    // Focus after release should not crash on `selectedKeys.find`
+    fireEvent.focus(container.querySelector('[role="tree"]'));
   });
 
   it('`undefined` means uncontrolled', () => {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1168,11 +1168,17 @@ describe('Tree Basic', () => {
     fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
     expect(nodeCount(uncontrolled)).toBe(1);
 
-    const { container: controlled } = render(
+    const { container: controlled, rerender } = render(
       <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
     );
     expect(nodeCount(controlled)).toBe(1);
     fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(controlled)).toBe(1);
+
+    // Switching an existing value to `null` collapses
+    rerender(<Tree treeData={treeData} expandedKeys={['p']} />);
+    expect(nodeCount(controlled)).toBe(2);
+    rerender(<Tree treeData={treeData} expandedKeys={null} />);
     expect(nodeCount(controlled)).toBe(1);
   });
 

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef, react/no-multi-comp, no-console,
-react/no-unused-state, react/prop-types, no-return-assign */
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 import { resetWarned, spyElementPrototypes } from '@rc-component/util';

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1156,7 +1156,7 @@ describe('Tree Basic', () => {
     ).toHaveLength(1);
   });
 
-  it('`undefined` is uncontrolled but `null` is a controlled empty value', () => {
+  it('`undefined` means uncontrolled', () => {
     const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
     const nodeCount = (container: HTMLElement) =>
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode').length;
@@ -1168,17 +1168,12 @@ describe('Tree Basic', () => {
     fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
     expect(nodeCount(uncontrolled)).toBe(1);
 
-    const { container: controlled, rerender } = render(
-      <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
+    // An empty array is still controlled, so it wins over `defaultExpandAll`
+    const { container: controlled } = render(
+      <Tree treeData={treeData} expandedKeys={[]} defaultExpandAll />,
     );
     expect(nodeCount(controlled)).toBe(1);
     fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
-    expect(nodeCount(controlled)).toBe(1);
-
-    // Switching an existing value to `null` collapses
-    rerender(<Tree treeData={treeData} expandedKeys={['p']} />);
-    expect(nodeCount(controlled)).toBe(2);
-    rerender(<Tree treeData={treeData} expandedKeys={null} />);
     expect(nodeCount(controlled)).toBe(1);
   });
 

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1150,9 +1150,30 @@ describe('Tree Basic', () => {
     ).toHaveLength(2);
 
     rerender(renderTree({ expandedKeys: undefined }));
-
-    // Click should not crash
     fireEvent.click(container.querySelector('.rc-tree-switcher'));
+    expect(
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),
+    ).toHaveLength(1);
+  });
+
+  it('`undefined` is uncontrolled but `null` is a controlled empty value', () => {
+    const treeData = [{ key: 'p', title: 'p', children: [{ key: 'c', title: 'c' }] }];
+    const nodeCount = (container: HTMLElement) =>
+      container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode').length;
+
+    const { container: uncontrolled } = render(
+      <Tree treeData={treeData} expandedKeys={undefined} defaultExpandAll />,
+    );
+    expect(nodeCount(uncontrolled)).toBe(2);
+    fireEvent.click(uncontrolled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(uncontrolled)).toBe(1);
+
+    const { container: controlled } = render(
+      <Tree treeData={treeData} expandedKeys={null} defaultExpandAll />,
+    );
+    expect(nodeCount(controlled)).toBe(1);
+    fireEvent.click(controlled.querySelector('.rc-tree-switcher'));
+    expect(nodeCount(controlled)).toBe(1);
   });
 
   it('controlled should block expanded', () => {

--- a/tests/Tree.spec.tsx
+++ b/tests/Tree.spec.tsx
@@ -1150,6 +1150,8 @@ describe('Tree Basic', () => {
     ).toHaveLength(2);
 
     rerender(renderTree({ expandedKeys: undefined }));
+
+    // Click should not crash
     fireEvent.click(container.querySelector('.rc-tree-switcher'));
     expect(
       container.querySelector('.rc-tree-list-holder').querySelectorAll('.rc-tree-treenode'),

--- a/tests/TreeMotion.spec.tsx
+++ b/tests/TreeMotion.spec.tsx
@@ -262,6 +262,7 @@ describe('Tree Motion', () => {
 
     rerender(
       renderTree({
+        expandedKeys: ['parent'],
         treeData: [
           {
             key: 'parent',


### PR DESCRIPTION
Stacked on #1069 — the diff shows both until that one merges; only the last commit (`chore: drop stale eslint-disable comments`) belongs to this PR.

Removes file-level `eslint-disable` comments in `docs/examples/basic.jsx`, `src/util.tsx` and `tests/Tree.spec.tsx` whose rules are no longer enabled or triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化树组件受控与非受控状态的切换逻辑。
  - 将受控属性设为 `undefined` 时，树会正确恢复为非受控模式并重置相关状态。
  - 修复释放 `expandedKeys` 后树无法再次展开或可能发生异常的问题。
  - 明确区分 `undefined` 与空数组：空数组仍表示受控状态。
  - 更新树数据或节点标题时，父节点的展开状态可保持稳定。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->